### PR TITLE
Add a JSON-RPC server to the Verifier

### DIFF
--- a/boba_community/fraud-detector/docker-compose-fraud-detector.yml
+++ b/boba_community/fraud-detector/docker-compose-fraud-detector.yml
@@ -16,7 +16,7 @@ services:
     image: bobanetwork/verifier_dtl:${TARGET_NAME}
     build:
       context: ../..
-      dockerfile: ./boba_community/fraud-detector-new/docker/Dockerfile.verifier_dtl
+      dockerfile: ./boba_community/fraud-detector/docker/Dockerfile.verifier_dtl
       args:
         TARGET_NAME: ${TARGET_NAME}
     env_file:
@@ -72,7 +72,7 @@ services:
       replicas: 1
     build:
       context: ../..
-      dockerfile: ./boba_community/fraud-detector-new/docker/Dockerfile.fraud-detector
+      dockerfile: ./boba_community/fraud-detector/docker/Dockerfile.fraud-detector
     environment:
       L1_NODE_WEB3_URL: ${L1_RPC_ENDPOINT}
       L2_NODE_WEB3_URL: ${L2_RPC_ENDPOINT}

--- a/boba_community/fraud-detector/docker-compose-fraud-detector.yml
+++ b/boba_community/fraud-detector/docker-compose-fraud-detector.yml
@@ -79,8 +79,6 @@ services:
       VERIFIER_WEB3_URL: http://verifier_l2geth:8545
       ADDRESS_MANAGER_ADDRESS: ${ADDRESS_MANAGER}
       L1_MAINNET_DEPLOYMENT_BLOCK: ${ETH1_CTC_DEPLOYMENT_HEIGHT}
-# FUTURE - fraud-detector can generate a status page and serve it over HTTP. For now
-# it only logs to stdout.  
-#    ports:
-#      - ${FRAUD_CHECKER_HTTP_PORT:-8555}:8555
+    ports:
+      - ${FRAUD_CHECKER_HTTP_PORT:-8555}:8555
  

--- a/boba_community/fraud-detector/docker/Dockerfile.fraud-detector
+++ b/boba_community/fraud-detector/docker/Dockerfile.fraud-detector
@@ -1,5 +1,6 @@
 FROM python:3.8
 RUN pip install web3
+RUN pip install jsonrpclib
 COPY boba_community/fraud-detector-new/fraud-detector.py /
 COPY /packages/contracts/artifacts/contracts/L1/rollup/StateCommitmentChain.sol/StateCommitmentChain.json /contracts/StateCommitmentChain.json
 COPY /packages/contracts/artifacts/contracts/libraries/resolver/Lib_AddressManager.sol/Lib_AddressManager.json /contracts/Lib_AddressManager.json

--- a/boba_community/fraud-detector/docker/Dockerfile.fraud-detector
+++ b/boba_community/fraud-detector/docker/Dockerfile.fraud-detector
@@ -1,7 +1,7 @@
 FROM python:3.8
 RUN pip install web3
 RUN pip install jsonrpclib
-COPY boba_community/fraud-detector-new/fraud-detector.py /
+COPY boba_community/fraud-detector/fraud-detector.py /
 COPY /packages/contracts/artifacts/contracts/L1/rollup/StateCommitmentChain.sol/StateCommitmentChain.json /contracts/StateCommitmentChain.json
 COPY /packages/contracts/artifacts/contracts/libraries/resolver/Lib_AddressManager.sol/Lib_AddressManager.json /contracts/Lib_AddressManager.json
 

--- a/boba_community/fraud-detector/docker/Dockerfile.verifier_dtl
+++ b/boba_community/fraud-detector/docker/Dockerfile.verifier_dtl
@@ -1,6 +1,6 @@
 FROM bobanetwork/data-transport-layer
 ARG TARGET_NAME
 
-COPY boba_community/fraud-detector-new/deployments/${TARGET_NAME}/state-dump.latest.json /opt/optimism/packages/data-transport-layer/state-dumps/state-dump.latest.json
+COPY boba_community/fraud-detector/deployments/${TARGET_NAME}/state-dump.latest.json /opt/optimism/packages/data-transport-layer/state-dumps/state-dump.latest.json
 
 ENTRYPOINT ["node", "dist/src/services/run.js"]


### PR DESCRIPTION
Now provides a mechanism to query the status over JSON-RPC, e.g.

 curl -d '{"jsonrpc":"2.0", "method":"status", "id":1}' http://127.0.0.1:8555

 {"result":
  {
   "matchedBlock": 7788,
   "matchedRoot": "0x0b40758bc7b6c2f9a95dc4af995a3c514a3b217d58e426c4f12bc94a0d6c8a0c",
   "timestamp": 1636139431.9659643,
   "isOK": true
  },"id": 1, "jsonrpc": "2.0"
 }