### PR TITLE
Fix relayer event query

### DIFF
--- a/packages/boba/message-relayer-fast/src/service.ts
+++ b/packages/boba/message-relayer-fast/src/service.ts
@@ -498,11 +498,14 @@ export class MessageRelayerService extends BaseService<MessageRelayerOptions> {
       return SCCEvent[0]
     }
 
-    let startingBlock = this.state.lastQueriedL1Block
-    while (
-      startingBlock < (await this.options.l1RpcProvider.getBlockNumber())
-    ) {
-      this.state.lastQueriedL1Block = startingBlock
+    let startingBlock = this.state.lastQueriedL1Block + 1
+    const maxBlock = await this.options.l1RpcProvider.getBlockNumber()
+    while (startingBlock <= maxBlock) {
+      const endBlock = Math.min(
+        startingBlock + this.options.getLogsInterval,
+        maxBlock
+      )
+
       this.logger.info('Querying events', {
         startingBlock,
         endBlock: startingBlock + this.options.getLogsInterval,
@@ -512,11 +515,19 @@ export class MessageRelayerService extends BaseService<MessageRelayerOptions> {
         await this.state.StateCommitmentChain.queryFilter(
           this.state.StateCommitmentChain.filters.StateBatchAppended(),
           startingBlock,
-          startingBlock + this.options.getLogsInterval
+          endBlock
         )
 
+      const ebn = []
+      events.forEach(e => {
+        ebn.push(e.blockNumber)
+      })
+      this.logger.info('Queried Events', { startingBlock, endBlock, ebn })
+
       this.state.eventCache = this.state.eventCache.concat(events)
-      startingBlock += this.options.getLogsInterval
+
+      this.state.lastQueriedL1Block = endBlock
+      startingBlock = endBlock + 1
 
       // We need to stop syncing early once we find the event we're looking for to avoid putting
       // *all* events into memory at the same time. Otherwise we'll get OOM killed.


### PR DESCRIPTION
Re-structure the event query logic in the Relayer to avoid situations where messages are not relayed until the service is restarted. I have also applied the same logic to the relevant section of the message-relayer-fast. 