### PR TITLE
Experiment: set startblock to 42 rather than 0

### DIFF
--- a/l2geth/core/blockchain.go
+++ b/l2geth/core/blockchain.go
@@ -225,7 +225,7 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, chainConfig *par
 	if err != nil {
 		return nil, err
 	}
-	bc.genesisBlock = bc.GetBlockByNumber(0)
+	bc.genesisBlock = bc.GetBlockByNumber(42)
 	if bc.genesisBlock == nil {
 		return nil, ErrNoGenesis
 	}

--- a/l2geth/core/genesis.go
+++ b/l2geth/core/genesis.go
@@ -270,7 +270,7 @@ func (g *Genesis) ToBlock(db ethdb.Database) *types.Block {
 	}
 	root := statedb.IntermediateRoot(false)
 	head := &types.Header{
-		Number:     new(big.Int).SetUint64(g.Number),
+		Number:     new(big.Int).SetUint64(42/*g.Number*/),
 		Nonce:      types.EncodeNonce(g.Nonce),
 		Time:       g.Timestamp,
 		ParentHash: g.ParentHash,
@@ -298,9 +298,9 @@ func (g *Genesis) ToBlock(db ethdb.Database) *types.Block {
 // The block is committed as the canonical head block.
 func (g *Genesis) Commit(db ethdb.Database) (*types.Block, error) {
 	block := g.ToBlock(db)
-	if block.Number().Sign() != 0 {
-		return nil, fmt.Errorf("can't commit genesis block with number > 0")
-	}
+	// if block.Number().Sign() != 0 {
+	// 	return nil, fmt.Errorf("can't commit genesis block with number > 0")
+	// }
 	config := g.Config
 	if config == nil {
 		config = params.AllEthashProtocolChanges

--- a/l2geth/core/headerchain.go
+++ b/l2geth/core/headerchain.go
@@ -98,7 +98,7 @@ func NewHeaderChain(chainDb ethdb.Database, config *params.ChainConfig, engine c
 		engine:        engine,
 	}
 
-	hc.genesisHeader = hc.GetHeaderByNumber(0)
+	hc.genesisHeader = hc.GetHeaderByNumber(42)
 	if hc.genesisHeader == nil {
 		return nil, ErrNoGenesis
 	}

--- a/l2geth/internal/ethapi/api.go
+++ b/l2geth/internal/ethapi/api.go
@@ -871,7 +871,7 @@ func DoCall(ctx context.Context, b Backend, args CallArgs, blockNrOrHash rpc.Blo
 		}
 		if block != nil {
 			txs := block.Transactions()
-			if header.Number.Uint64() != 0 {
+			if header.Number.Uint64() != 42 {
 				if len(txs) != 1 {
 					return nil, 0, false, fmt.Errorf("block %d has more than 1 transaction", header.Number.Uint64())
 				}

--- a/packages/batch-submitter/src/batch-submitter/batch-submitter.ts
+++ b/packages/batch-submitter/src/batch-submitter/batch-submitter.ts
@@ -69,6 +69,7 @@ export abstract class BatchSubmitter {
   public abstract _updateChainInfo(): Promise<void>
 
   public async submitNextBatch(): Promise<TransactionReceipt> {
+
     if (typeof this.l2ChainId === 'undefined') {
       this.l2ChainId = await this._getL2ChainId()
     }
@@ -88,9 +89,17 @@ export abstract class BatchSubmitter {
       this.logger.info(
         'Syncing mode enabled! Skipping batch submission and clearing queue...'
       )
-      return this._onSync()
+      //return this._onSync()
     }
     const range = await this._getBatchStartAndEnd()
+    
+    this.logger.info(
+        'getBatchStartAndEnd', {
+          rangeStart: range.start,
+          rangeEnd: range.end,
+        }
+      )
+
     if (!range) {
       return
     }

--- a/packages/batch-submitter/src/batch-submitter/batch-submitter.ts
+++ b/packages/batch-submitter/src/batch-submitter/batch-submitter.ts
@@ -86,23 +86,23 @@ export abstract class BatchSubmitter {
     })
 
     if (this.syncing === true) {
-      this.logger.info(
-        'Syncing mode enabled! Skipping batch submission and clearing queue...'
-      )
+      // this.logger.info(
+      //   'Syncing mode enabled! Skipping batch submission and clearing queue...'
+      // )
       //return this._onSync()
     }
     const range = await this._getBatchStartAndEnd()
     
-    this.logger.info(
-        'getBatchStartAndEnd', {
-          rangeStart: range.start,
-          rangeEnd: range.end,
-        }
-      )
-
     if (!range) {
       return
     }
+
+    this.logger.info(
+      'getBatchStartAndEnd', {
+        rangeStart: range.start,
+        rangeEnd: range.end,
+      }
+    )
 
     return this._submitBatch(range.start, range.end)
   }

--- a/packages/batch-submitter/src/batch-submitter/state-batch-submitter.ts
+++ b/packages/batch-submitter/src/batch-submitter/state-batch-submitter.ts
@@ -123,7 +123,7 @@ export class StateBatchSubmitter extends BatchSubmitter {
 
     // We will submit state roots for txs which have been in the tx chain for a while.
     const totalElements: number =
-      (await this.ctcContract.getTotalElements()).toNumber() + this.blockOffset
+      (await this.ctcContract.getTotalElements()).toNumber() //+ this.blockOffset
     this.logger.info('Retrieved total elements from CTC', {
       totalElements,
     })

--- a/packages/batch-submitter/src/exec/run-batch-submitter.ts
+++ b/packages/batch-submitter/src/exec/run-batch-submitter.ts
@@ -103,7 +103,7 @@ export const run = async () => {
   // Default is 1 because Geth normally has 1 more block than L1
   const BLOCK_OFFSET = config.uint(
     'block-offset',
-    parseInt(env.BLOCK_OFFSET, 10) || 1
+    43//parseInt(env.BLOCK_OFFSET, 10) || 1
   )
 
   /* Logger */

--- a/packages/data-transport-layer/src/services/l2-ingestion/service.ts
+++ b/packages/data-transport-layer/src/services/l2-ingestion/service.ts
@@ -96,7 +96,15 @@ export class L2IngestionService extends BaseService<L2IngestionServiceOptions> {
     while (this.running) {
       try {
         const highestSyncedL2BlockNumber =
-          (await this.state.db.getHighestSyncedUnconfirmedBlock()) || 43 //1 + 42 = 43
+          (await this.state.db.getHighestSyncedUnconfirmedBlock()) || 42 //1 + 42 = 43
+          //43 gives this: 
+          /*
+          {"level":30,"time":1638659712553,"fromBlock":43,"toBlock":42,"msg":"Synchronizing unconfirmed transactions from Layer 2 (Optimistic Ethereum)"}
+
+{"level":40,"time":1638659712553,"startBlockNumber":43,"endBlockNumber":42,"msg":"Cannot query with start block number larger than end block number"}
+*/
+//so this needs to be set to 42 rather than 1
+
 
         const currentL2Block = await this.state.l2RpcProvider.getBlockNumber()
 

--- a/packages/data-transport-layer/src/services/l2-ingestion/service.ts
+++ b/packages/data-transport-layer/src/services/l2-ingestion/service.ts
@@ -96,7 +96,7 @@ export class L2IngestionService extends BaseService<L2IngestionServiceOptions> {
     while (this.running) {
       try {
         const highestSyncedL2BlockNumber =
-          (await this.state.db.getHighestSyncedUnconfirmedBlock()) || 1
+          (await this.state.db.getHighestSyncedUnconfirmedBlock()) || 43 //1 + 42 = 43
 
         const currentL2Block = await this.state.l2RpcProvider.getBlockNumber()
 


### PR DESCRIPTION
This results in:

1/ `{"level":50,"time":1638657909379,"extra":{"message":"TypeError: blocks is not iterable","stack":"TypeError: blocks is not iterable\n` which makes sense -> need to change init config for the DTL

2/ l2geth_1           | DEBUG[12-04|22:44:11.852] Problem committing transaction      msg="Block created with not 0 transactions at 43" which may or may not be related