### PR TITLE
TURING - Update evm.go - intercept Turing call earlier before first evm.call 

### DIFF
--- a/boba_community/fraud-detector/README.md
+++ b/boba_community/fraud-detector/README.md
@@ -29,6 +29,7 @@ The central idea is that if two (or more) systems look at the same transactions,
 ## 2. What do when you discover a state root mismatch
 
 Congratulations! The security of the L2 depends on community monitoring of the operator's actions. If you have discovered a state root mismatch, please file a GitHub issue (https://github.com/omgnetwork/optimism-v2/issues). We should have a good response / clarification for you quickly. In the future, with the Boba governance token, additional mechanisms will be released to incentivize and reward community monitoring of the Boba L2.  
+
 ## 3. Running the Fraud Detector, the Verifier, and the Data Transport Layer (DTL)
 
 **Requirements**: you will need a command line and Docker. Before filing GitHub issues, please make sure Docker is installed and *running*. 

--- a/boba_community/fraud-detector/fraud-detector.py
+++ b/boba_community/fraud-detector/fraud-detector.py
@@ -77,12 +77,28 @@ except:
 batch_size =1000
 
 rpc = [None]*4
-rpc[1] = Web3(Web3.HTTPProvider(os.environ['L1_NODE_WEB3_URL']))
-assert (rpc[1].isConnected())
-logger.debug ("Connected to L1_NODE_WEB3_URL")
 
-rpc[2] = Web3(Web3.HTTPProvider(os.environ['L2_NODE_WEB3_URL']))
-assert (rpc[2].isConnected())
+while True:
+  try:
+    rpc[1] = Web3(Web3.HTTPProvider(os.environ['L1_NODE_WEB3_URL']))
+    assert (rpc[1].isConnected())
+    break
+  except:
+    logger.info ("Waiting for L1...")
+    time.sleep(10)
+
+rpc[1].middleware_onion.inject(geth_poa_middleware, layer=0)
+logger.debug("Connected to L1_NODE_WEB3_URL")
+
+while True:
+  try:
+    rpc[2] = Web3(Web3.HTTPProvider(os.environ['L2_NODE_WEB3_URL']))
+    assert (rpc[2].isConnected())
+    break
+  except:
+    logger.info ("Waiting for L2...")
+    time.sleep(10)
+
 rpc[2].middleware_onion.inject(geth_poa_middleware, layer=0)
 logger.debug("Connected to L2_NODE_WEB3_URL")
 

--- a/l2geth/core/vm/evm.go
+++ b/l2geth/core/vm/evm.go
@@ -282,7 +282,7 @@ func bobaTuringRandom(input []byte) hexutil.Bytes {
 // FIXME - needs error handling. For now, bails out and lets the contract
 // be called a second time with the original parameters. 2nd failure is not intercepted.
 
-func bobaTuringCall(input []byte) hexutil.Bytes {
+func bobaTuringCall(input []byte, caller common.Address) hexutil.Bytes {
 	
 	// don't go off-chain unless actually needed...
 	// if we have data and if the time is right,
@@ -300,6 +300,9 @@ func bobaTuringCall(input []byte) hexutil.Bytes {
 				"cached", turingCache.value)
 		}
 	} 
+
+	log.Debug("TURING-20 bobaTuringCall:Caller",
+		"caller", caller.String())
 
 	var responseStringEnc string
 	var responseString []byte
@@ -388,7 +391,7 @@ func bobaTuringCall(input []byte) hexutil.Bytes {
 
 	if client != nil {
 		log.Debug("TURING-6 bobaTuringCall:Calling off-chain client at", "url", url)
-		if err := client.Call(&responseStringEnc, "turing", payload); err != nil {
+		if err := client.Call(&responseStringEnc, caller.String(), payload); err != nil {
 			log.Warn("TURING-7 bobaTuringCall:Client error", "err", err)
 			return append(methodID, hexutil.MustDecode(fmt.Sprintf("0x%064x", 13))...) //Client Error
 		}
@@ -519,7 +522,7 @@ func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas 
 	var updated_input hexutil.Bytes
 
 	if isTuring2 {
-		updated_input = bobaTuringCall(input)
+		updated_input = bobaTuringCall(input, caller.Address())
 		ret, err = run(evm, contract, updated_input, false)
 	} else if isGetRand2 {
 		updated_input = bobaTuringRandom(input)

--- a/l2geth/core/vm/evm.go
+++ b/l2geth/core/vm/evm.go
@@ -511,8 +511,11 @@ func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas 
 	} 
 
 	// bobaTuringCall takes the original calldata, figures out what needs
-	// to be done, and then synthesizes a 'new_in' calldata that does not 
-	// lead to the revert (by changing rType from 1 to 2)
+	// to be done, and then synthesizes a 'new_in' calldata
+	// this system is compatible with the previous system, since the rType
+	// is changed before the evm.call, so the call goes right though the helper contract
+	// ToDo - change the helper contract to provide better error messages based on 
+	// changing the revert string of anything except for rType 2
 	var updated_input hexutil.Bytes
 
 	if isTuring2 {

--- a/l2geth/core/vm/evm.go
+++ b/l2geth/core/vm/evm.go
@@ -500,18 +500,6 @@ func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas 
 		}()
 	}
 
-	// so this is the first invocation, which will revert
-	// we should have all the information here to manipulate the input
-    // is this a special call?
-
-    inputHexUtil := hexutil.Bytes(input)
-	restHexUtil := inputHexUtil[:4]
-	methodID := input[:4]
-
-	log.Debug("TURING-EXP methodID", 
-		"methodID", restHexUtil,
-		"input", input)
-
 	//methodID for GetResponse is 7d93616c -> [125 147 97 108]
 	isTuring2 := bytes.Contains(input, []byte{125, 147, 97, 108})
 
@@ -519,10 +507,8 @@ func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas 
 	isGetRand2 := bytes.Contains(input, []byte{73, 61, 87, 214})
 
 	if isTuring2 || isGetRand2 {
-		log.Debug("TURING REQUEST", "methodID", methodID)
-	} else {
-		log.Debug("TURING-EXP methodID mismatch", "methodID mismatch", methodID)
-	}
+		log.Debug("TURING REQUEST", "input", input)
+	} 
 
 	// bobaTuringCall takes the original calldata, figures out what needs
 	// to be done, and then synthesizes a 'new_in' calldata that does not 

--- a/ops/docker-compose.yml
+++ b/ops/docker-compose.yml
@@ -129,7 +129,7 @@ services:
       context: ./docker/hardhat
       dockerfile: Dockerfile
     ports:
-        # expose the service to the host for integration testing
+      # expose the service to the host for integration testing
       - ${L1CHAIN_HTTP_PORT:-9545}:8545
 
   deployer:
@@ -142,30 +142,30 @@ services:
       dockerfile: ./ops/docker/Dockerfile.deployer
     entrypoint: ./deployer.sh
     environment:
-        FRAUD_PROOF_WINDOW_SECONDS: 0
-        L1_NODE_WEB3_URL: http://l1_chain:8545
-        # these keys are hardhat's first 2 accounts, DO NOT use in production
-        << : *deployer_pk
-        << : *sequencer_pk
-        << : *proposer_pk
-        << : *relayer_pk
-        # setting the whitelist owner to address(0) disables the whitelist
-        WHITELIST_OWNER: "0x0000000000000000000000000000000000000000"
-        L1_FEE_WALLET_ADDRESS: "0x391716d440c151c42cdf1c95c1d83a5427bca52c"
-        L2_CHAIN_ID: 31338
-        L2_BLOCK_GAS_LIMIT: 11000000
-        BLOCK_SIGNER_ADDRESS: "0x00000398232E2064F896018496b4b44b3D62751F"
-        GAS_PRICE_ORACLE_OWNER: "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"
-        GAS_PRICE_ORACLE_OVERHEAD: "2750"
-        GAS_PRICE_ORACLE_SCALAR: "1500000"
-        GAS_PRICE_ORACLE_L1_BASE_FEE: "1"
-        GAS_PRICE_ORACLE_GAS_PRICE: "1"
-        GAS_PRICE_ORACLE_DECIMALS: "1"
-        # skip compilation when run in docker-compose, since the contracts
-        # were already compiled in the builder step
-        NO_COMPILE: 1
-        DTL_REGISTRY_URL: http://dtl:8081/addresses.json
-        DTL_STATE_DUMP_REGISTRY_URL: http://dtl:8081/state-dump.latest.json
+      FRAUD_PROOF_WINDOW_SECONDS: 0
+      L1_NODE_WEB3_URL: http://l1_chain:8545
+      # these keys are hardhat's first 2 accounts, DO NOT use in production
+      << : *deployer_pk
+      << : *sequencer_pk
+      << : *proposer_pk
+      << : *relayer_pk
+      # setting the whitelist owner to address(0) disables the whitelist
+      WHITELIST_OWNER: "0x0000000000000000000000000000000000000000"
+      L1_FEE_WALLET_ADDRESS: "0x391716d440c151c42cdf1c95c1d83a5427bca52c"
+      L2_CHAIN_ID: 31338
+      L2_BLOCK_GAS_LIMIT: 11000000
+      BLOCK_SIGNER_ADDRESS: "0x00000398232E2064F896018496b4b44b3D62751F"
+      GAS_PRICE_ORACLE_OWNER: "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"
+      GAS_PRICE_ORACLE_OVERHEAD: "2750"
+      GAS_PRICE_ORACLE_SCALAR: "1500000"
+      GAS_PRICE_ORACLE_L1_BASE_FEE: "1"
+      GAS_PRICE_ORACLE_GAS_PRICE: "1"
+      GAS_PRICE_ORACLE_DECIMALS: "1"
+      # skip compilation when run in docker-compose, since the contracts
+      # were already compiled in the builder step
+      NO_COMPILE: 1
+      DTL_REGISTRY_URL: http://dtl:8081/addresses.json
+      DTL_STATE_DUMP_REGISTRY_URL: http://dtl:8081/state-dump.latest.json
 
   # deploys boba contracts and serves contract addresses
   boba_deployer:
@@ -202,11 +202,11 @@ services:
     # set the rest of the env vars for the network whcih do not
     # depend on the docker-compose setup
     environment:
-        # connect to the 2 layers
-        DATA_TRANSPORT_LAYER__L1_RPC_ENDPOINT: http://l1_chain:8545
-        DATA_TRANSPORT_LAYER__L2_RPC_ENDPOINT: http://l2geth:8545
-        DATA_TRANSPORT_LAYER__SYNC_FROM_L2: 'true'
-        DATA_TRANSPORT_LAYER__L2_CHAIN_ID: 31338
+      # connect to the 2 layers
+      DATA_TRANSPORT_LAYER__L1_RPC_ENDPOINT: http://l1_chain:8545
+      DATA_TRANSPORT_LAYER__L2_RPC_ENDPOINT: http://l2geth:8545
+      DATA_TRANSPORT_LAYER__SYNC_FROM_L2: 'true'
+      DATA_TRANSPORT_LAYER__L2_CHAIN_ID: 31338
     ports:
       - ${DTL_PORT:-7878}:7878
       - ${REGISTRY_PORT:-8080}:8081
@@ -224,16 +224,16 @@ services:
     env_file:
       - ./envs/geth.env
     environment:
-        ETH1_HTTP: http://l1_chain:8545
-        ROLLUP_TIMESTAMP_REFRESH: 5s
-        ROLLUP_STATE_DUMP_PATH: http://dtl:8081/state-dump.latest.json
-        # connecting to the DTL
-        ROLLUP_CLIENT_HTTP: http://dtl:7878
-        ETH1_CTC_DEPLOYMENT_HEIGHT: 8
-        RETRIES: 100
-        # no need to keep this secret, only used internally to sign blocks
-        BLOCK_SIGNER_KEY: "6587ae678cf4fc9a33000cdbf9f35226b71dcc6a4684a31203241f9bcfd55d27"
-        BLOCK_SIGNER_ADDRESS: "0x00000398232E2064F896018496b4b44b3D62751F"
+      ETH1_HTTP: http://l1_chain:8545
+      ROLLUP_TIMESTAMP_REFRESH: 5s
+      ROLLUP_STATE_DUMP_PATH: http://dtl:8081/state-dump.latest.json
+      # connecting to the DTL
+      ROLLUP_CLIENT_HTTP: http://dtl:7878
+      ETH1_CTC_DEPLOYMENT_HEIGHT: 8
+      RETRIES: 100
+      # no need to keep this secret, only used internally to sign blocks
+      BLOCK_SIGNER_KEY: "6587ae678cf4fc9a33000cdbf9f35226b71dcc6a4684a31203241f9bcfd55d27"
+      BLOCK_SIGNER_ADDRESS: "0x00000398232E2064F896018496b4b44b3D62751F"
     ports:
       - ${L2GETH_HTTP_PORT:-8545}:8545
       - ${L2GETH_WS_PORT:-8546}:8546
@@ -303,11 +303,11 @@ services:
     env_file:
       - ./envs/batches.env
     environment:
-        L1_NODE_WEB3_URL: http://l1_chain:8545
-        L2_NODE_WEB3_URL: http://l2geth:8545
-        URL: http://dtl:8081/addresses.json
-        << : *sequencer_pk
-        << : *proposer_pk
+      L1_NODE_WEB3_URL: http://l1_chain:8545
+      L2_NODE_WEB3_URL: http://l2geth:8545
+      URL: http://dtl:8081/addresses.json
+      << : *sequencer_pk
+      << : *proposer_pk
 
   verifier:
     depends_on:
@@ -373,16 +373,16 @@ services:
     env_file:
       - ./envs/geth.env
     environment:
-        ETH1_HTTP: http://l1_chain:8545
-        ROLLUP_STATE_DUMP_PATH: http://dtl:8081/state-dump.latest.json
-        ROLLUP_CLIENT_HTTP: http://dtl:7878
-        ROLLUP_BACKEND: 'l2'
-        ROLLUP_VERIFIER_ENABLE: 'true'
-        ETH1_CTC_DEPLOYMENT_HEIGHT: 8
-        RETRIES: 100
-        # no need to keep this secret, only used internally to sign blocks
-        BLOCK_SIGNER_KEY: "6587ae678cf4fc9a33000cdbf9f35226b71dcc6a4684a31203241f9bcfd55d27"
-        BLOCK_SIGNER_ADDRESS: "0x00000398232E2064F896018496b4b44b3D62751F"
+      ETH1_HTTP: http://l1_chain:8545
+      ROLLUP_STATE_DUMP_PATH: http://dtl:8081/state-dump.latest.json
+      ROLLUP_CLIENT_HTTP: http://dtl:7878
+      ROLLUP_BACKEND: 'l2'
+      ROLLUP_VERIFIER_ENABLE: 'true'
+      ETH1_CTC_DEPLOYMENT_HEIGHT: 8
+      RETRIES: 100
+      # no need to keep this secret, only used internally to sign blocks
+      BLOCK_SIGNER_KEY: "6587ae678cf4fc9a33000cdbf9f35226b71dcc6a4684a31203241f9bcfd55d27"
+      BLOCK_SIGNER_ADDRESS: "0x00000398232E2064F896018496b4b44b3D62751F"
     ports:
       - ${L2GETH_HTTP_PORT:-8549}:8545
       - ${L2GETH_WS_PORT:-8550}:8546

--- a/ops/docker-compose.yml
+++ b/ops/docker-compose.yml
@@ -315,7 +315,7 @@ services:
       - dtl
     image: bobanetwork/l2geth:latest
     deploy:
-      replicas: 0
+      replicas: 1
     build:
       context: ..
       dockerfile: ./ops/docker/Dockerfile.geth
@@ -323,16 +323,41 @@ services:
     env_file:
       - ./envs/geth.env
     environment:
-        ETH1_HTTP: http://l1_chain:8545
-        ROLLUP_STATE_DUMP_PATH: http://dtl:8081/state-dump.latest.json
-        ROLLUP_CLIENT_HTTP: http://dtl:7878
-        ROLLUP_BACKEND: 'l1'
-        ROLLUP_VERIFIER_ENABLE: 'true'
-        ETH1_CTC_DEPLOYMENT_HEIGHT: 8
-        RETRIES: 100
+      ETH1_HTTP: http://l1_chain:8545
+      ROLLUP_STATE_DUMP_PATH: http://dtl:8081/state-dump.latest.json
+      ROLLUP_CLIENT_HTTP: http://dtl:7878
+      ROLLUP_BACKEND: 'l1'
+      ROLLUP_VERIFIER_ENABLE: 'true'
+      ETH1_CTC_DEPLOYMENT_HEIGHT: 8
+      RETRIES: 100
+      # no need to keep this secret, only used internally to sign blocks
+      BLOCK_SIGNER_KEY: "6587ae678cf4fc9a33000cdbf9f35226b71dcc6a4684a31203241f9bcfd55d27"
+      BLOCK_SIGNER_ADDRESS: "0x00000398232E2064F896018496b4b44b3D62751F"
     ports:
       - ${VERIFIER_HTTP_PORT:-8547}:8545
       - ${VERIFIER_WS_PORT:-8548}:8546
+
+  fraud-detector:
+    depends_on:
+     - dtl
+     - verifier
+    image: bobanetwork/fraud-detector:latest
+    deploy:
+      replicas: 1
+    build:
+      context: ..
+      dockerfile: ./ops/docker/Dockerfile.fraud-detector
+    environment:
+      L1_NODE_WEB3_URL: http://l1_chain:8545
+      L1_CONFIRMATIONS: 8
+      L2_NODE_WEB3_URL: http://l2geth:8545
+      L2_CHECK_INTERVAL: 10
+      VERIFIER_WEB3_URL: http://verifier:8545
+      ADDRESS_MANAGER_ADDRESS: "0x5FbDB2315678afecb367f032d93F642f64180aa3"
+      L1_DEPLOYMENT_BLOCK: 8
+      L2_START_BLOCK: 1
+    ports:
+      - ${FRAUD_CHECKER_HTTP_PORT:-8555}:8555
 
   replica:
     depends_on:
@@ -340,7 +365,7 @@ services:
       - dtl
     image: bobanetwork/l2geth:latest
     deploy:
-      replicas: 1
+      replicas: 0
     build:
       context: ..
       dockerfile: ./ops/docker/Dockerfile.geth

--- a/ops/docker/Dockerfile.fraud-detector
+++ b/ops/docker/Dockerfile.fraud-detector
@@ -1,0 +1,8 @@
+FROM python:3.8
+RUN pip install web3
+RUN pip install jsonrpclib
+COPY boba_community/fraud-detector/fraud-detector.py /
+COPY /packages/contracts/artifacts/contracts/L1/rollup/StateCommitmentChain.sol/StateCommitmentChain.json /contracts/StateCommitmentChain.json
+COPY /packages/contracts/artifacts/contracts/libraries/resolver/Lib_AddressManager.sol/Lib_AddressManager.json /contracts/Lib_AddressManager.json
+
+CMD [ "python", "-u", "./fraud-detector.py" ]

--- a/ops/up_local.sh
+++ b/ops/up_local.sh
@@ -40,6 +40,7 @@ if [[ $BUILD == 1 ]]; then
     docker-compose build -- boba_message-relayer-fast
     docker-compose build -- gas_oracle
     docker-compose build -- boba_deployer
+    docker-compose build -- fraud-detector
 elif [[ $BUILD == 0 ]]; then
   if [[ $NO_PULL == 1 ]]; then
     echo "Using already present images"

--- a/packages/boba/turing/AWS_code/turing_oracle.py
+++ b/packages/boba/turing/AWS_code/turing_oracle.py
@@ -4,47 +4,70 @@ import math
 import textwrap
 import struct
 
+api_key = 'YOUR_API_KEY'
+authorized_contract = '0xOF_YOUR_HELPER_CONTRACT'
+  
 def lambda_handler(event, context):
   
-    input = json.loads(event["body"])
+  input = json.loads(event["body"])
+  print("DEBUG: from Geth:", input)
+  
+  # check authorisation   
+  callerAddress = input['method']
     
-    api_key = 'YOUR_API_KEY_HERE'
-    
-    print("DEBUG: from Geth:", input)
-
-    param4HexString = input['params'][0]
-    param4HexString = param4HexString.removeprefix("0x")
-
-    params = textwrap.wrap(param4HexString, 64)
-    
-    str_length = int(params[2], 16) * 2
-    request = params[3]
-    bytes_object = bytes.fromhex(request[0:str_length])
-    pair = bytes_object.decode("ASCII")
-
-    requestURL = 'https://api.polygon.io/v1/last/crypto/' + pair + '?apiKey=' + api_key
-
-    http = urllib3.PoolManager()
-    resp = http.request("GET", requestURL)
-
-    result = json.loads(resp.data)
-    
-    print("from endpoint:", result['last']['price'])
-    
-    price = result['last']['price'] * 100
-    timestamp = result['last']['timestamp']
-    
-    res = '0x{0:0{1}x}'.format(int(64),64)
-    res = res + '{0:0{1}x}'.format(int(price),64)
-    res = res + '{0:0{1}x}'.format(int(timestamp),64)
-
-    returnPayload = {
-      'statusCode': 200,
-      'body': json.dumps({
-        "result": res
-      })
-    }
-
+  if callerAddress.lower() != authorized_contract.lower() :
+    returnPayload = {'statusCode': 403}  # forbidden
     print('return payload:', returnPayload)
+    return returnPayload    
+  
+  # get calling parameters    
+  paramsHexString = input['params'][0]
+  paramsHexString = paramsHexString.removeprefix("0x")
+  params = textwrap.wrap(paramsHexString, 64)
+  
+  # 0000000000000000000000000000000000000000000000000000000000000060
+  # 0000000000000000000000000000000000000000000000000000000000000020
+  # 0000000000000000000000000000000000000000000000000000000000000007
+  # 4254432f55534400000000000000000000000000000000000000000000000000 BTC-USD, for example
     
-    return returnPayload
+  str_length = int(params[2], 16) * 2
+  
+  request = params[3]
+  bytes_object = bytes.fromhex(request[0:str_length])
+  pair = bytes_object.decode("ASCII")
+    
+  requestURL = 'https://api.polygon.io/v1/last/crypto/' + pair + '?apiKey=' + api_key
+    
+  # Create a PoolManager instance for sending requests.
+  http = urllib3.PoolManager()
+
+  # Send a POST request and receive a HTTPResponse object.
+  resp = http.request("GET", requestURL)
+
+  print(resp.data)
+    
+  result = json.loads(resp.data)
+    
+  print("from endpoint:", result['last']['price'])
+    
+  price = result['last']['price'] * 100
+  timestamp = result['last']['timestamp']
+    
+  # create return payload
+  res = '0x{0:0{1}x}'.format(int(64),64)
+  res = res + '{0:0{1}x}'.format(int(price),64) #the price
+  res = res + '{0:0{1}x}'.format(int(timestamp),64) #the timestamp
+    
+  print("res:", res)
+
+  returnPayload = {
+    'statusCode': 200,
+    'body': json.dumps({
+      "result": res
+    })
+  }
+
+  print('return payload:', returnPayload)
+    
+  return returnPayload
+


### PR DESCRIPTION
In this experiment, we use the methodID to trigger Turing, and then we modify the calldata before the first invocation of `evm call`.

Benefits - simpler system, no changes to fraud detector needed, less expensive, no revert
Disadvantages - does not preserve a record of the unmodified call to Turing - as far as the evm is concerned, the initial call never happened