### PR TITLE
[Turing-3] Turing remove magic and reduce footprint

### DIFF
--- a/l2geth/accounts/abi/bind/backends/simulated.go
+++ b/l2geth/accounts/abi/bind/backends/simulated.go
@@ -333,7 +333,7 @@ func (b *SimulatedBackend) CallContract(ctx context.Context, call ethereum.CallM
 	if err != nil {
 		return nil, err
 	}
-	rval, _, _, err, _ := b.callContract(ctx, call, b.blockchain.CurrentBlock(), state)
+	rval, _, _, err := b.callContract(ctx, call, b.blockchain.CurrentBlock(), state)
 	return rval, err
 }
 
@@ -343,7 +343,7 @@ func (b *SimulatedBackend) PendingCallContract(ctx context.Context, call ethereu
 	defer b.mu.Unlock()
 	defer b.pendingState.RevertToSnapshot(b.pendingState.Snapshot())
 
-	rval, _, _, err, _ := b.callContract(ctx, call, b.pendingBlock, b.pendingState)
+	rval, _, _, err := b.callContract(ctx, call, b.pendingBlock, b.pendingState)
 	return rval, err
 }
 
@@ -386,7 +386,7 @@ func (b *SimulatedBackend) EstimateGas(ctx context.Context, call ethereum.CallMs
 		call.Gas = gas
 
 		snapshot := b.pendingState.Snapshot()
-		_, _, failed, err, _ := b.callContract(ctx, call, b.pendingBlock, b.pendingState)
+		_, _, failed, err := b.callContract(ctx, call, b.pendingBlock, b.pendingState)
 		b.pendingState.RevertToSnapshot(snapshot)
 
 		if err != nil || failed {
@@ -414,7 +414,7 @@ func (b *SimulatedBackend) EstimateGas(ctx context.Context, call ethereum.CallMs
 
 // callContract implements common code between normal and pending contract calls.
 // state is modified during execution, make sure to copy it if necessary.
-func (b *SimulatedBackend) callContract(ctx context.Context, call ethereum.CallMsg, block *types.Block, statedb *state.StateDB) ([]byte, uint64, bool, error, []byte) {
+func (b *SimulatedBackend) callContract(ctx context.Context, call ethereum.CallMsg, block *types.Block, statedb *state.StateDB) ([]byte, uint64, bool, error) {
 	// Ensure message is initialized properly.
 	if call.GasPrice == nil {
 		call.GasPrice = big.NewInt(1)

--- a/l2geth/cmd/geth/retesteth.go
+++ b/l2geth/cmd/geth/retesteth.go
@@ -655,7 +655,7 @@ func (api *RetestethAPI) AccountRange(ctx context.Context,
 			context := core.NewEVMContext(msg, block.Header(), api.blockchain, nil)
 			// Not yet the searched for transaction, execute on top of the current state
 			vmenv := vm.NewEVM(context, statedb, api.blockchain.Config(), vm.Config{})
-			if _, _, _, err, _ := core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(tx.Gas())); err != nil {
+			if _, _, _, err := core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(tx.Gas())); err != nil {
 				return AccountRangeResult{}, fmt.Errorf("transaction %#x failed: %v", tx.Hash(), err)
 			}
 			// Ensure any modifications are committed to the state
@@ -765,7 +765,7 @@ func (api *RetestethAPI) StorageRangeAt(ctx context.Context,
 			context := core.NewEVMContext(msg, block.Header(), api.blockchain, nil)
 			// Not yet the searched for transaction, execute on top of the current state
 			vmenv := vm.NewEVM(context, statedb, api.blockchain.Config(), vm.Config{})
-			if _, _, _, err, _ := core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(tx.Gas())); err != nil {
+			if _, _, _, err := core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(tx.Gas())); err != nil {
 				return StorageRangeResult{}, fmt.Errorf("transaction %#x failed: %v", tx.Hash(), err)
 			}
 			// Ensure any modifications are committed to the state

--- a/l2geth/core/state_prefetcher.go
+++ b/l2geth/core/state_prefetcher.go
@@ -80,6 +80,6 @@ func precacheTransaction(config *params.ChainConfig, bc ChainContext, author *co
 	context := NewEVMContext(msg, header, bc, author)
 	vm := vm.NewEVM(context, statedb, config, cfg)
 
-	_, _, _, err, _ = ApplyMessage(vm, msg, gaspool)
+	_, _, _, err = ApplyMessage(vm, msg, gaspool)
 	return err
 }

--- a/l2geth/core/state_processor.go
+++ b/l2geth/core/state_processor.go
@@ -24,7 +24,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rollup/fees"
 )

--- a/l2geth/core/state_processor.go
+++ b/l2geth/core/state_processor.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rollup/fees"
 )
@@ -105,11 +106,9 @@ func ApplyTransaction(
 	// Create a new context to be used in the EVM environment
 	context := NewEVMContext(msg, header, bc, author)
 
-	// log.Debug("TURING state_processor.go entering ApplyTransaction - setting up EVM and context", "context", context)
-
 	// Create a new environment which holds all relevant information
 	// about the transaction and calling mechanisms. This environment also
-	// contains Turing data, which is critical for verifiers and replicas.
+	// contains Turing data - if available - which is critical for verifiers and replicas.
 	vmenv := vm.NewEVM(context, statedb, config, cfg)
 
 	// UsingOVM
@@ -122,7 +121,12 @@ func ApplyTransaction(
 	}
 
 	// Apply the transaction to the current state (included in the env)
-	_, gas, failed, err, turing := ApplyMessage(vmenv, msg, gp)
+	_, gas, failed, err := ApplyMessage(vmenv, msg, gp)
+
+	// TURING Update the tx metadata, if a Turing call took place...
+	if len(vmenv.Context.Turing) > 1 {
+		tx.SetL1Turing(vmenv.Context.Turing) //this is too late? ... so things don't work?
+	}
 
 	if err != nil {
 		return nil, err
@@ -156,7 +160,7 @@ func ApplyTransaction(
 	receipt.BlockHash = statedb.BlockHash()
 	receipt.BlockNumber = header.Number
 	receipt.TransactionIndex = uint(statedb.TxIndex())
-	receipt.Turing = turing
+	receipt.Turing = vmenv.Context.Turing
 
 	return receipt, err
 }

--- a/l2geth/eth/api_tracer.go
+++ b/l2geth/eth/api_tracer.go
@@ -502,7 +502,7 @@ func (api *PrivateDebugAPI) traceBlock(ctx context.Context, block *types.Block, 
 		vmctx := core.NewEVMContext(msg, block.Header(), api.eth.blockchain, nil)
 
 		vmenv := vm.NewEVM(vmctx, statedb, api.eth.blockchain.Config(), vm.Config{})
-		if _, _, _, err, _ := core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(msg.Gas())); err != nil {
+		if _, _, _, err := core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(msg.Gas())); err != nil {
 			failed = err
 			break
 		}
@@ -596,7 +596,7 @@ func (api *PrivateDebugAPI) standardTraceBlockToFile(ctx context.Context, block 
 		}
 		// Execute the transaction and flush any traces to disk
 		vmenv := vm.NewEVM(vmctx, statedb, api.eth.blockchain.Config(), vmConf)
-		_, _, _, err, _ = core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(msg.Gas()))
+		_, _, _, err = core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(msg.Gas()))
 		if writer != nil {
 			writer.Flush()
 		}
@@ -758,7 +758,7 @@ func (api *PrivateDebugAPI) traceTx(ctx context.Context, message core.Message, v
 	// Run the transaction with tracing enabled.
 	vmenv := vm.NewEVM(vmctx, statedb, api.eth.blockchain.Config(), vm.Config{Debug: true, Tracer: tracer})
 
-	ret, gas, failed, err, _ := core.ApplyMessage(vmenv, message, new(core.GasPool).AddGas(message.Gas()))
+	ret, gas, failed, err := core.ApplyMessage(vmenv, message, new(core.GasPool).AddGas(message.Gas()))
 	if err != nil {
 		return nil, fmt.Errorf("tracing failed: %v", err)
 	}
@@ -812,7 +812,7 @@ func (api *PrivateDebugAPI) computeTxEnv(blockHash common.Hash, txIndex int, ree
 		}
 		// Not yet the searched for transaction, execute on top of the current state
 		vmenv := vm.NewEVM(context, statedb, api.eth.blockchain.Config(), vm.Config{})
-		if _, _, _, err, _ := core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(tx.Gas())); err != nil {
+		if _, _, _, err := core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(tx.Gas())); err != nil {
 			return nil, vm.Context{}, nil, fmt.Errorf("transaction %#x failed: %v", tx.Hash(), err)
 		}
 		// Ensure any modifications are committed to the state

--- a/l2geth/internal/ethapi/api.go
+++ b/l2geth/internal/ethapi/api.go
@@ -925,7 +925,7 @@ func DoCall(ctx context.Context,
 	// Setup the gas pool (also for unmetered requests)
 	// and apply the message.
 	gp := new(core.GasPool).AddGas(math.MaxUint64)
-	res, gas, failed, err, _ := core.ApplyMessage(evm, msg, gp)
+	res, gas, failed, err := core.ApplyMessage(evm, msg, gp)
 	if err := vmError(); err != nil {
 		return nil, 0, false, err
 	}

--- a/packages/batch-submitter/src/batch-submitter/tx-batch-submitter.ts
+++ b/packages/batch-submitter/src/batch-submitter/tx-batch-submitter.ts
@@ -753,8 +753,9 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
   private async _getL2BatchElement(blockNumber: number): Promise<BatchElement> {
 
     // Idea - manipulate the rawTransaction as early as possible, so we do not have to change even more of the encode/decode 
-    // logic - note that this is basically adding a second encoder/decoder before the 'normal' one, which encosed total length
-    // the 'normal' one will now specify the TOTAL length (new_turing_header + rawTransaction + turing (if != 0)) rather than 
+    // logic - note that this is basically adding a second encoder/decoder before the 'normal' one, which encodes total length
+    //
+    // The 'normal' one will now specify the TOTAL length (new_turing_header + rawTransaction + turing (if != 0)) rather than 
     // just remove0x(rawTransaction).length / 2
 
     const block = await this._getBlock(blockNumber)
@@ -769,8 +770,8 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
 
     if (this._isSequencerTx(block)) {
       batchElement.isSequencerTx = true
-      let rawTransaction = block.transactions[0].rawTransaction
       const turing = block.transactions[0].l1Turing
+      let rawTransaction = block.transactions[0].rawTransaction
 
       if (turing.length > 4) {
         // FYI - we sometimes use short (length <= 4) non-zero Turing strings for debug purposes

--- a/packages/batch-submitter/src/batch-submitter/tx-batch-submitter.ts
+++ b/packages/batch-submitter/src/batch-submitter/tx-batch-submitter.ts
@@ -772,18 +772,15 @@ export class TransactionBatchSubmitter extends BatchSubmitter {
       batchElement.isSequencerTx = true
       const turing = block.transactions[0].l1Turing
       let rawTransaction = block.transactions[0].rawTransaction
-
       if (turing.length > 4) {
         // FYI - we sometimes use short (length <= 4) non-zero Turing strings for debug purposes
         // Chop those off at this stage
         // Only propagate the data through the system if it's a real Turing payload
         const headerTuringLengthField = remove0x(BigNumber.from(remove0x(turing).length / 2).toHexString()).padStart(6, '0')
-        console.log("Turing payload:", {turing, length: turing.length, headerTuringLengthField})
         rawTransaction = '0x' + headerTuringLengthField + remove0x(rawTransaction) + remove0x(turing)
       } else {
         rawTransaction = '0x' + '000000' + remove0x(rawTransaction)
       }
-      console.log("Final Turing Field:", {final_rawTransaction: rawTransaction})
       batchElement.rawTransaction = rawTransaction
     }
 

--- a/packages/data-transport-layer/src/services/l1-ingestion/handlers/sequencer-batch-appended.ts
+++ b/packages/data-transport-layer/src/services/l1-ingestion/handlers/sequencer-batch-appended.ts
@@ -118,42 +118,12 @@ export const handleEventsSequencerBatchAppended: EventHandlerSet<
         // First, parse the new length field...
         const sTxHexString = toHexString(sequencerTransaction)
         const turingLength = parseInt(remove0x(sTxHexString).slice(0,6), 16)
-        console.log("TuringLength", turingLength)
-
-/*
-      // const size = b.slice(offset, offset + 6)
-      // offset += 6
-      // const raw = b.slice(offset, offset + parseInt(size, 16) * 2)
-      // transactions.push(add0x(raw))
-      // offset += raw.length
-
-    if (this._isSequencerTx(block)) {
-      batchElement.isSequencerTx = true
-      let rawTransaction = block.transactions[0].rawTransaction
-      const turing = block.transactions[0].l1Turing
-
-      if (turing.length > 4) {
-        // FYI - we sometimes use short (length <= 4) non-zero Turing strings for debug purposes
-        // Chop those off at this stage
-        // Only propagate the data through the system if it's a real Turing payload
-        const headerTuringLengthField = remove0x(BigNumber.from(remove0x(turing).length / 2).toHexString()).padStart(6, '0')
-        console.log("Turing payload:", {turing, length: turing.length, headerTuringLengthField})
-        rawTransaction = '0x' + headerTuringLengthField + remove0x(rawTransaction) + remove0x(turing)
-      } else {
-        rawTransaction = '0x' + '000000' + remove0x(rawTransaction)
-      }
-      console.log("Final Turing Field:", {final_rawTransaction: rawTransaction})
-      batchElement.rawTransaction = rawTransaction
-    }
-*/
-        //const turingIndex = sequencerTransaction.indexOf('424242', 0, 'hex')
-        // The indexOf() method returns the index within the calling String object of the first occurrence of the specified value
 
         let turing = Buffer.from('0')
 
         if (turingLength > 0) {
           //we have Turing payload
-          turing = sequencerTransaction.slice(-turingLength) //might have to be multiplied
+          turing = sequencerTransaction.slice(-turingLength)
           sequencerTransaction = sequencerTransaction.slice(3, -turingLength)
           // The `3` chops off the Turing length header field, and the `-turingLength` chops off the Turing bytes
           console.log('Found a Turing payload at (neg) position:', {

--- a/packages/data-transport-layer/src/services/l1-ingestion/handlers/sequencer-batch-appended.ts
+++ b/packages/data-transport-layer/src/services/l1-ingestion/handlers/sequencer-batch-appended.ts
@@ -278,7 +278,9 @@ const parseSequencerBatchTransaction = (
   calldata: Buffer,
   offset: number
 ): Buffer => {
-  const transactionLength = BigNumber.from(calldata.slice(offset, offset + 3)).toNumber()
+  const transactionLength = BigNumber.from(
+    calldata.slice(offset, offset + 3)
+  ).toNumber()
   return calldata.slice(offset + 3, offset + 3 + transactionLength)
 }
 
@@ -287,18 +289,8 @@ const decodeSequencerBatchTransaction = (
   l2ChainId: number
 ): DecodedSequencerBatchTransaction | null => {
   try {
-    // console.log(`Trying to decode this transaction`, {
-    //   transaction,
-    // })
 
     const decodedTx = ethers.utils.parseTransaction(transaction)
-
-    // console.log(`Got this back`, { decodedTx })
-    // console.log(`Got this back`, {
-    //   V: decodedTx.v,
-    //   parse: parseSignatureVParam(decodedTx.v, l2ChainId),
-    //   l2ChainId,
-    // })
 
     return {
       nonce: BigNumber.from(decodedTx.nonce).toString(),

--- a/packages/data-transport-layer/src/services/l1-ingestion/handlers/sequencer-batch-appended.ts
+++ b/packages/data-transport-layer/src/services/l1-ingestion/handlers/sequencer-batch-appended.ts
@@ -97,13 +97,10 @@ export const handleEventsSequencerBatchAppended: EventHandlerSet<
     let enqueuedCount = 0
     let nextTxPointer = 15 + 16 * numContexts
     for (let i = 0; i < numContexts; i++) {
-
       const contextPointer = 15 + 16 * i
-
       const context = parseSequencerBatchContext(calldata, contextPointer)
 
       for (let j = 0; j < context.numSequencedTransactions; j++) {
-        
         let sequencerTransaction = parseSequencerBatchTransaction(
           calldata,
           nextTxPointer
@@ -272,8 +269,6 @@ const parseSequencerBatchContext = (
   }
 }
 
-// Each calldata slice starts out with the length of the transaction?
-// is this done at the level of the Geth or in the batch submitter?
 const parseSequencerBatchTransaction = (
   calldata: Buffer,
   offset: number
@@ -281,6 +276,7 @@ const parseSequencerBatchTransaction = (
   const transactionLength = BigNumber.from(
     calldata.slice(offset, offset + 3)
   ).toNumber()
+
   return calldata.slice(offset + 3, offset + 3 + transactionLength)
 }
 

--- a/packages/data-transport-layer/src/services/l1-ingestion/handlers/sequencer-batch-appended.ts
+++ b/packages/data-transport-layer/src/services/l1-ingestion/handlers/sequencer-batch-appended.ts
@@ -131,6 +131,9 @@ export const handleEventsSequencerBatchAppended: EventHandlerSet<
             turing: toHexString(turing),
             restoredSequencerTransaction: toHexString(sequencerTransaction),
           })
+        } else {
+          // The `3` chops off the Turing length header field, which is zero in this case (0: 00 1: 00 2: 00)
+          sequencerTransaction = sequencerTransaction.slice(3)
         }
 
         const decoded = decodeSequencerBatchTransaction(


### PR DESCRIPTION
This remove the `424242` junction indicator and replaces it with a `turingLength` field in the metadata header