### PR TITLE
Add access control to TuringHelper contract

### DIFF
--- a/packages/boba/turing/contracts/TuringHelper.sol
+++ b/packages/boba/turing/contracts/TuringHelper.sol
@@ -21,7 +21,7 @@ contract TuringHelper is ITuringHelper, Ownable {
   modifier onlyPermittedCaller() {
     require(
       permittedCaller[msg.sender],
-      'Invalid Caller Contract'
+      'Invalid Caller Address'
     );
     _;
   }

--- a/packages/boba/turing/contracts/TuringHelper.sol
+++ b/packages/boba/turing/contracts/TuringHelper.sol
@@ -1,18 +1,45 @@
 //SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.9;
 
+import '@openzeppelin/contracts/access/Ownable.sol';
+
 import "./ITuringHelper.sol";
 
-contract TuringHelper is ITuringHelper {
+contract TuringHelper is ITuringHelper, Ownable {
 
   TuringHelper Self;
 
+  // This protects your own credits for this helper contract
+  mapping(address => bool) public permittedCaller;
+
+  event AddPermittedCaller(address _callerContractAddress);
+  event RemovePermittedCaller(address _callerContractAddress);
   event OffchainResponse(uint version, bytes responseData);
   event OffchainRandom(uint version, uint256 random);
   event Offchain42(uint version, uint256 random);
 
+  modifier onlyPermittedCaller() {
+    require(
+      permittedCaller[msg.sender],
+      'Invalid Caller Contract'
+    );
+    _;
+  }
+
   constructor () public {
     Self = TuringHelper(address(this));
+  }
+
+  function addPermittedCaller(address _callerContractAddress)
+    public onlyOwner {
+      permittedCaller[_callerContractAddress] = true;
+      emit AddPermittedCaller(_callerContractAddress);
+  }
+
+  function removePermittedCaller(address _callerContractAddress)
+    public onlyOwner {
+      permittedCaller[_callerContractAddress] = false;
+      emit RemovePermittedCaller(_callerContractAddress);
   }
 
   function GetErrorCode(uint32 rType)
@@ -41,7 +68,7 @@ contract TuringHelper is ITuringHelper {
      This response is then passed back to the caller.
   */
   function GetResponse(uint32 rType, string memory _url, bytes memory _payload)
-    public returns (bytes memory) {
+    public onlyPermittedCaller returns (bytes memory) {
 
     require (msg.sender == address(this), "Turing:GetResponse:msg.sender != address(this)");
     require (_payload.length > 0, "Turing:GetResponse:no payload");
@@ -50,7 +77,7 @@ contract TuringHelper is ITuringHelper {
   }
 
   function GetRandom(uint32 rType, uint256 _random)
-    public returns (uint256) {
+    public onlyPermittedCaller returns (uint256) {
 
     require (msg.sender == address(this), "Turing:GetResponse:msg.sender != address(this)");
     require (rType == 2, string(GetErrorCode(rType)));
@@ -58,7 +85,7 @@ contract TuringHelper is ITuringHelper {
   }
 
   function Get42(uint32 rType, uint256 _random)
-    public returns (uint256) {
+    public onlyPermittedCaller returns (uint256) {
 
     require (msg.sender == address(this), "Turing:GetResponse:msg.sender != address(this)");
     require (rType == 2, string(GetErrorCode(rType)));
@@ -79,7 +106,7 @@ contract TuringHelper is ITuringHelper {
      offchain interaction.
   */
   function TuringTx(string memory _url, bytes memory _payload)
-    public override returns (bytes memory) {
+    public onlyPermittedCaller override returns (bytes memory) {
       require (_payload.length > 0, "Turing:TuringTx:no payload");
 
       /* Initiate the request. This can't be a local function call
@@ -92,7 +119,7 @@ contract TuringHelper is ITuringHelper {
   }
 
   function TuringRandom()
-    public returns (uint256) {
+    public onlyPermittedCaller returns (uint256) {
 
       uint256 response = Self.GetRandom(1, 0);
       emit OffchainRandom(0x01, response);
@@ -100,7 +127,7 @@ contract TuringHelper is ITuringHelper {
   }
 
   function Turing42()
-    public returns (uint256) {
+    public onlyPermittedCaller returns (uint256) {
 
       uint256 response = Self.Get42(2, 42);
       emit Offchain42(0x01, response);

--- a/packages/boba/turing/contracts/TuringHelper.sol
+++ b/packages/boba/turing/contracts/TuringHelper.sol
@@ -12,8 +12,8 @@ contract TuringHelper is ITuringHelper, Ownable {
   // This protects your own credits for this helper contract
   mapping(address => bool) public permittedCaller;
 
-  event AddPermittedCaller(address _callerContractAddress);
-  event RemovePermittedCaller(address _callerContractAddress);
+  event AddPermittedCaller(address _callerAddress);
+  event RemovePermittedCaller(address _callerAddress);
   event OffchainResponse(uint version, bytes responseData);
   event OffchainRandom(uint version, uint256 random);
   event Offchain42(uint version, uint256 random);
@@ -30,16 +30,16 @@ contract TuringHelper is ITuringHelper, Ownable {
     Self = TuringHelper(address(this));
   }
 
-  function addPermittedCaller(address _callerContractAddress)
+  function addPermittedCaller(address _callerAddress)
     public onlyOwner {
-      permittedCaller[_callerContractAddress] = true;
-      emit AddPermittedCaller(_callerContractAddress);
+      permittedCaller[_callerAddress] = true;
+      emit AddPermittedCaller(_callerAddress);
   }
 
-  function removePermittedCaller(address _callerContractAddress)
+  function removePermittedCaller(address _callerAddress)
     public onlyOwner {
-      permittedCaller[_callerContractAddress] = false;
-      emit RemovePermittedCaller(_callerContractAddress);
+      permittedCaller[_callerAddress] = false;
+      emit RemovePermittedCaller(_callerAddress);
   }
 
   function GetErrorCode(uint32 rType)


### PR DESCRIPTION
when someone deploys a `turingHelper` contract, anyone else can use it, depleting the owner's credits. fix - add basic access control system where the helper only allows designated other contracts to call it. 