### PR TITLE
Turing cache cleanup + fixes

### DIFF
--- a/l2geth/core/error.go
+++ b/l2geth/core/error.go
@@ -35,7 +35,4 @@ var (
 
 	// ErrNoGenesis is returned when there is no Genesis Block.
 	ErrNoGenesis = errors.New("genesis not found in chain")
-
-	// ErrTuringRetry indicates a Turing cache miss in a real transaction (not an estimateGas)
-	ErrTuringRetry = errors.New("turing retry needed")
 )

--- a/l2geth/core/state_processor.go
+++ b/l2geth/core/state_processor.go
@@ -109,10 +109,6 @@ func ApplyTransaction(config *params.ChainConfig, bc ChainContext, author *commo
 	// Apply the transaction to the current state (included in the env)
 	_, gas, failed, err := ApplyMessage(vmenv, msg, gp)
 
-	// if err == vm.ErrTuringWouldBlock {
-	// 	return nil, ErrTuringRetry // this is in "core", not "core/vm"
-	// }
-
 	// TURING Update the tx metadata, if a Turing call took place...
 	if len(vmenv.Context.Turing) > 1 {
 		tx.SetL1Turing(vmenv.Context.Turing)

--- a/l2geth/core/state_transition.go
+++ b/l2geth/core/state_transition.go
@@ -283,13 +283,6 @@ func (st *StateTransition) TransitionDb() (ret []byte, usedGas uint64, failed bo
 		ret, st.gas, vmerr = evm.Call(sender, st.to(), st.data, st.gas, st.value)
 	}
 
-	// if vmerr == vm.ErrTuringWouldBlock {
-	// 	// Roll back the nonce (FIXME - also ensure that all gas accounting etc. has been rolled back)
-	// 	log.Debug("TURING evm.Call returned ErrTuringWouldBlock")
-	// 	st.state.SetNonce(msg.From(), st.state.GetNonce(msg.From())-1)
-	// 	return nil, 0, true, vmerr
-	// }
-
 	if vmerr != nil {
 		log.Debug("VM returned with error", "err", vmerr, "ret", hexutil.Encode(ret))
 		// The only possible consensus-error would be if there wasn't

--- a/l2geth/core/vm/errors.go
+++ b/l2geth/core/vm/errors.go
@@ -30,5 +30,4 @@ var (
 	ErrTuringDepth              = errors.New("turing call depth exceeded")
 	ErrTuringEmpty              = errors.New("turing replay data not found")
 	ErrGasUintOverflow          = errors.New("gas uint64 overflow")
-	ErrTuringWouldBlock         = errors.New("turing missing cache entry")
 )

--- a/l2geth/core/vm/evm.go
+++ b/l2geth/core/vm/evm.go
@@ -413,9 +413,9 @@ func (evm *EVM) bobaTuringCall(input []byte, caller common.Address, mayBlock boo
 			// Since no Boba credit is consumed in an estimateGas call, we put a
 			// "failed" entry into the cache here so that a failed offchain call
 			// can't be called repeatedly as a DoS attack.
-			errVal := make([]byte, len(retError))
-			copy(errVal, retError)
-			tCache.Put(key, errVal)
+			//errVal := make([]byte, len(retError))
+			//copy(errVal, retError)
+			tCache.Put(key, retError)
 		} else {
 			retError[35] = 20 // Missing cache entry
 			return retError, 20

--- a/l2geth/core/vm/instructions.go
+++ b/l2geth/core/vm/instructions.go
@@ -763,10 +763,6 @@ func opCall(pc *uint64, interpreter *EVMInterpreter, contract *Contract, memory 
 	}
 	ret, returnGas, err := interpreter.evm.Call(contract, toAddr, args, gas, value)
 
-	// if err == ErrTuringWouldBlock {
-	// 	return nil, err
-	// }
-
 	if err != nil {
 		stack.push(interpreter.intPool.getZero())
 	} else {

--- a/l2geth/internal/ethapi/api.go
+++ b/l2geth/internal/ethapi/api.go
@@ -1749,36 +1749,7 @@ func (s *PublicTransactionPoolAPI) SendRawTransaction(ctx context.Context, encod
 	txMeta := types.NewTransactionMeta(nil, 0, nil, nil, types.QueueOriginSequencer, nil, nil, encodedTx)
 	tx.SetTransactionMeta(txMeta)
 
-	ret, err := SubmitTransaction(ctx, s.b, tx)
-
-	// if err != nil && err.Error() == "turing retry needed" {
-	// 	blockNrOrHash := rpc.BlockNumberOrHashWithNumber(rpc.PendingBlockNumber)
-	// 	tdBytes := hexutil.Bytes(tx.Data())
-
-	// 	signer := types.MakeSigner(s.b.ChainConfig(), s.b.CurrentBlock().Number())
-	// 	from, err := types.Sender(signer, tx)
-
-	// 	callArgs := CallArgs{
-	// 		From:     &from,
-	// 		To:       tx.To(),
-	// 		GasPrice: (*hexutil.Big)(tx.GasPrice()),
-	// 		Value:    (*hexutil.Big)(tx.Value()),
-	// 		Data:     &tdBytes,
-	// 	}
-
-	// 	_, _, failed, err2 := DoCall(ctx, s.b, callArgs, blockNrOrHash, nil, &vm.Config{}, 0, new(big.Int).SetUint64(8000000))
-	// 	if failed {
-	// 		log.Error("TURING api.go gasEstimate failed", "err", err2)
-	// 		return common.Hash{}, err
-	// 	}
-
-	// 	log.Debug("TURING ethapi/api.go calling again after gasEstimate")
-	// 	ret, err = SubmitTransaction(ctx, s.b, tx)
-
-	// 	log.Debug("TURING ethapi/api.go second call is done", "ret", ret, "err", err)
-	// }
-
-	return ret, err
+	return SubmitTransaction(ctx, s.b, tx)
 }
 
 // Sign calculates an ECDSA signature for:

--- a/l2geth/miner/worker.go
+++ b/l2geth/miner/worker.go
@@ -870,12 +870,6 @@ func (w *worker) commitTransactions(txs *types.TransactionsByPriceAndNonce, coin
 			w.current.tcount++
 			txs.Shift()
 
-		// case core.ErrTuringRetry:
-		// 	// Turing transaction needs to be retried after populating the cache. This special
-		// 	// error code rolls back the first attempt as if it had never happened.
-		// 	txs.Shift()
-		// 	return 2
-
 		default:
 			// Strange error, discard the transaction and get the next in line (note, the
 			// nonce-too-high clause will prevent us from executing in vain).

--- a/l2geth/rollup/sync_service.go
+++ b/l2geth/rollup/sync_service.go
@@ -884,11 +884,6 @@ func (s *SyncService) applyTransactionToTip(tx *types.Transaction) error {
 
 	select {
 	case err := <-errCh:
-		// if err.Error() == "turing retry needed" {
-		// 	log.Debug("TURING sync_service intercepted ErrTuringRetry")
-		// 	tx.GetMeta().Index = nil
-		// 	return err
-		// }
 		log.Error("Got error waiting for transaction to be added to chain", "msg", err)
 		s.SetLatestL1Timestamp(ts)
 		s.SetLatestL1BlockNumber(bn)

--- a/packages/boba/turing/test/002_math.ts
+++ b/packages/boba/turing/test/002_math.ts
@@ -219,6 +219,13 @@ describe("Basic Math", function () {
     const result = parseInt(rawData.slice(-64), 16) / 100 
     expect(result.toFixed(5)).to.equal('33.51000')
   })
+  
+  it("should not re-use cache for a new Tx", async () => {
+    // The nonce is now part of the cache key, so after a completed Tx the
+    // next Tx should not see the previous cache entry.
+    let tr = await hello.multFloatNumbers(urlStr, '2.123', gasOverride)
+    await expect(tr.wait()).to.be.reverted
+  })
 
   it("should revert on a cache miss", async () => {
     let tr = await hello.multFloatNumbers(urlStr, '3.123', gasOverride)


### PR DESCRIPTION
Cache now trims expired entries periodically. Code cleaned up and restructured. Removed dead "retry" code. Updated the 002_math tests.