### PR TITLE
restart the l2 geth node

### DIFF
--- a/ops/docker-compose.yml
+++ b/ops/docker-compose.yml
@@ -240,6 +240,7 @@ services:
     entrypoint: sh ./geth.sh
     env_file:
       - ./envs/geth.env
+    restart: always
     environment:
       ETH1_HTTP: http://l1_chain:8545
       ROLLUP_TIMESTAMP_REFRESH: 5s


### PR DESCRIPTION
There are cases where the l2geth node dies in the integration tests for unknown reasons (it seems like the issue is transient and a restart would fix it):
```
2022-03-03T14:34:10.2715777Z [35;1mops_l2geth_1 exited with code 1
2022-03-03T14:34:10.1713480Z [35;1ml2geth_1                     |[0m Importing private key
2022-03-03T14:34:10.1714001Z [35;1ml2geth_1                     |[0m INFO [03-03|14:32:54.305] Maximum peer count                       ETH=50 LES=0 total=50
2022-03-03T14:34:10.1714724Z [35;1ml2geth_1                     |[0m INFO [03-03|14:32:54.306] Smartcard socket not found, disabling    err="stat /run/pcscd/pcscd.comm: no such file or directory"
2022-03-03T14:34:10.1715292Z [35;1ml2geth_1                     |[0m Address: {00000398232e2064f896018496b4b44b3d62751f}
2022-03-03T14:34:10.1715717Z [35;1ml2geth_1                     |[0m Initializing Geth node
2022-03-03T14:34:10.1716190Z [35;1ml2geth_1                     |[0m Fatal: invalid genesis file: unexpected EOF
2022-03-03T14:34:10.1716667Z [35;1ml2geth_1                     |[0m Fatal: invalid genesis file: unexpected EOF
2022-03-03T14:34:10.1717067Z [35;1ml2geth_1                     |[0m Starting Geth node
2022-03-03T14:34:10.1717575Z [35;1ml2geth_1                     |[0m DEBUG[03-03|14:32:56.268] Sanitizing Go's GC trigger               percent=100
2022-03-03T14:34:10.1718407Z [35;1ml2geth_1                     |[0m INFO [03-03|14:32:56.269] Maximum peer count                       ETH=50 LES=0 total=50
2022-03-03T14:34:10.1719067Z [35;1ml2geth_1                     |[0m INFO [03-03|14:32:56.269] Smartcard socket not found, disabling    err="stat /run/pcscd/pcscd.comm: no such file or directory"
2022-03-03T14:34:10.1719761Z [35;1ml2geth_1                     |[0m DEBUG[03-03|14:32:56.269] FS scan times                            list=50.298µs set=36.775µs diff=4.951µs
2022-03-03T14:34:10.1720657Z [35;1ml2geth_1                     |[0m TRACE[03-03|14:32:56.269] Started watching keystore folder         path=/root/.ethereum/keystore
2022-03-03T14:34:10.1721223Z [35;1ml2geth_1                     |[0m TRACE[03-03|14:32:56.269] Handled keystore changes                 time=52.181µs
2022-03-03T14:34:10.1722032Z [35;1ml2geth_1                     |[0m INFO [03-03|14:32:56.270] Starting peer-to-peer node               instance=Geth/v1.9.10-turing/linux-amd64/go1.15.15
2022-03-03T14:34:10.1722721Z [35;1ml2geth_1                     |[0m INFO [03-03|14:32:56.271] Allocated trie memory caches             clean=512.00MiB dirty=0.00B
2022-03-03T14:34:10.1723424Z [35;1ml2geth_1                     |[0m INFO [03-03|14:32:56.271] Allocated cache and file handles         database=/root/.ethereum/geth/chaindata cache=512.00MiB handles=524288
2022-03-03T14:34:10.1724188Z [35;1ml2geth_1                     |[0m DEBUG[03-03|14:32:56.290] Chain freezer table opened               database=/root/.ethereum/geth/chaindata/ancient table=headers items=0 size=0.00B
2022-03-03T14:34:10.1724950Z [35;1ml2geth_1                     |[0m DEBUG[03-03|14:32:56.292] Chain freezer table opened               database=/root/.ethereum/geth/chaindata/ancient table=hashes  items=0 size=0.00B
2022-03-03T14:34:10.1725792Z [35;1ml2geth_1                     |[0m DEBUG[03-03|14:32:56.294] Chain freezer table opened               database=/root/.ethereum/geth/chaindata/ancient table=bodies  items=0 size=0.00B
2022-03-03T14:34:10.1726581Z [35;1ml2geth_1                     |[0m DEBUG[03-03|14:32:56.296] Chain freezer table opened               database=/root/.ethereum/geth/chaindata/ancient table=receipts items=0 size=0.00B
2022-03-03T14:34:10.1727344Z [35;1ml2geth_1                     |[0m DEBUG[03-03|14:32:56.298] Chain freezer table opened               database=/root/.ethereum/geth/chaindata/ancient table=diffs    items=0 size=0.00B
2022-03-03T14:34:10.1728030Z [35;1ml2geth_1                     |[0m INFO [03-03|14:32:56.298] Opened ancient database                  database=/root/.ethereum/geth/chaindata/ancient
2022-03-03T14:34:10.1728585Z [35;1ml2geth_1                     |[0m INFO [03-03|14:32:56.298] Writing default main-net genesis block 
2022-03-03T14:34:10.1729108Z [35;1ml2geth_1                     |[0m DEBUG[03-03|14:32:56.298] Current full block hash unavailable 
2022-03-03T14:34:10.1729825Z [35;1ml2geth_1                     |[0m INFO [03-03|14:32:56.831] Persisted trie from memory database      nodes=24762 size=2.91MiB time=126.099892ms gcnodes=0 gcsize=0.00B gctime=0s livenodes=1 livesize=-82.00B
2022-03-03T14:34:10.1731012Z [35;1ml2geth_1                     |[0m INFO [03-03|14:32:56.831] Initialised chain configuration          config="{ChainID: 1 Homestead: 1150000 DAO: 1920000 DAOSupport: true EIP150: 2463000 EIP155: 2675000 EIP158: 2675000 Byzantium: 4370000 Constantinople: 7280000 Petersburg: 7280000 Istanbul: 9069000, Muir Glacier: 9200000, Berlin: <nil>, Engine: ethash}"
2022-03-03T14:34:10.1731826Z [35;1ml2geth_1                     |[0m INFO [03-03|14:32:56.831] Disk storage enabled for ethash caches   dir=/root/.ethereum/geth/ethash count=3
2022-03-03T14:34:10.1732459Z [35;1ml2geth_1                     |[0m INFO [03-03|14:32:56.831] Disk storage enabled for ethash DAGs     dir=/root/.ethash               count=2
2022-03-03T14:34:10.1733087Z [35;1ml2geth_1                     |[0m INFO [03-03|14:32:56.831] Initialising Ethereum protocol           versions="[64 63]" network=31338 dbversion=<nil>
2022-03-03T14:34:10.1733685Z [35;1ml2geth_1                     |[0m WARN [03-03|14:32:56.831] Upgrade blockchain database version      from=<nil> to=7
2022-03-03T14:34:10.1734507Z [35;1ml2geth_1                     |[0m INFO [03-03|14:32:56.832] Loaded most recent local header          number=0 hash=a5b96a…341783 td=17179869184 age=52y11mo4d
2022-03-03T14:34:10.1735587Z [35;1ml2geth_1                     |[0m INFO [03-03|14:32:56.832] Loaded most recent local full block      number=0 hash=a5b96a…341783 td=17179869184 age=52y11mo4d
2022-03-03T14:34:10.1736263Z [35;1ml2geth_1                     |[0m INFO [03-03|14:32:56.832] Loaded most recent local fast block      number=0 hash=a5b96a…341783 td=17179869184 age=52y11mo4d
2022-03-03T14:34:10.1736860Z [35;1ml2geth_1                     |[0m DEBUG[03-03|14:32:56.832] Reinjecting stale transactions           count=0
2022-03-03T14:34:10.1737444Z [35;1ml2geth_1                     |[0m INFO [03-03|14:32:56.832] Regenerated local transaction journal    transactions=0 accounts=0
2022-03-03T14:34:10.1738029Z [35;1ml2geth_1                     |[0m INFO [03-03|14:32:56.832] Running in sequencer mode                sync-backend=l1
2022-03-03T14:34:10.1738602Z [35;1ml2geth_1                     |[0m INFO [03-03|14:32:56.832] Fees                                     threshold-up=nil threshold-down=nil
2022-03-03T14:34:10.1739149Z [35;1ml2geth_1                     |[0m INFO [03-03|14:32:56.832] Enforce Fees                             set=false
2022-03-03T14:34:10.1739800Z [35;1ml2geth_1                     |[0m INFO [03-03|14:32:56.832] Configured rollup client                 url=http://dtl:7878 chain-id=1 ctc-deploy-height=8
```

https://pipelines.actions.githubusercontent.com/iK9dB2prHBU1YBVPA8kPQBYkhQSte4nAL8iVPhCcDHHJUFRRph/_apis/pipelines/1/runs/19602/signedlogcontent/70?urlExpires=2022-03-03T15%3A08%3A39.4378732Z&urlSigningMethod=HMACV1&urlSignature=7Wrkn%2FNlTXOhgtsO5%2FGQ%2FYUfsd%2FK7i0fWdsYxwN7C2s%3D