### PR TITLE
Inomurko/fix gas price oracle pk

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -19,6 +19,10 @@ jobs:
       label: ${{ steps.start-ec2-runner.outputs.label }}
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.1
+        with:
+          access_token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -41,7 +41,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 6
+      max-parallel: 4
       fail-fast: false
       matrix:
         include:
@@ -53,8 +53,6 @@ jobs:
           test-grep-filter: 'tag:mrf'
         - id: 4
           test-grep-filter: 'tag:other'
-        - id: 5
-          test-grep-filter: '^((?!tag:).)*$'
     outputs:
       label: ${{ steps.executioner.outputs.label }}
       ec2-instance-id: ${{ steps.executioner.outputs.ec2-instance-id }}
@@ -150,7 +148,7 @@ jobs:
       #   ports:
       #     - 5000:5000
     strategy:
-      max-parallel: 6
+      max-parallel: 4
       fail-fast: false
       matrix:
         include:
@@ -162,8 +160,6 @@ jobs:
           test-grep-filter: 'tag:mrf'
         - id: 4
           test-grep-filter: 'tag:other'
-        - id: 5
-          test-grep-filter: '^((?!tag:).)*$'
     steps:
       - uses: actions/download-artifact@v2
         id: download
@@ -229,7 +225,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
     strategy:
-      max-parallel: 6
+      max-parallel: 4
       fail-fast: false
       matrix:
         include:
@@ -237,7 +233,6 @@ jobs:
         - id: 2
         - id: 3
         - id: 4
-        - id: 5
     steps:
       - uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -72,7 +72,7 @@ jobs:
           mode: start
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           ec2-image-id: ami-00b46fa1102c70ff2
-          ec2-instance-type: m4.4xlarge
+          ec2-instance-type: t2.2xlarge
           subnet-id: subnet-905870ae
           security-group-id: sg-0855631d714870b32
       - name: Output the runner meta

--- a/.github/workflows/ts-packages.yml
+++ b/.github/workflows/ts-packages.yml
@@ -218,3 +218,37 @@ jobs:
 
       - name: Lint
         run: yarn lint:check
+
+  tagging:
+    name: Integration tests tagging
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Grep
+        working-directory: ./integration-tests
+        run: |
+          export SHELL=/bin/bash
+          set +eo pipefail
+          grep -rv "it('{tag:" --include \*.spec.ts  . | grep "it('"
+          if [[ $? -eq 1 ]]
+          then
+            echo "You're OK."
+            exit 0
+          else
+            echo "What did you do?"
+            exit 1
+          fi
+      - name: Grep
+        working-directory: ./integration-tests
+        run: |
+          export SHELL=/bin/bash
+          set +eo pipefail
+          grep -rv 'it("{tag:' --include \*.spec.ts  . | grep 'it("'
+          if [[ $? -eq 1 ]]
+          then
+            echo "You're OK."
+            exit 0
+          else
+            echo "What did you do?"
+            exit 1
+          fi

--- a/ops/docker-compose-side.yml
+++ b/ops/docker-compose-side.yml
@@ -1,5 +1,18 @@
 version: "3"
 
+# Account #19
+x-gas-price-oracle_pk: &gas-price-oracle_pk
+  GAS_PRICE_ORACLE_OWNER_PRIVATE_KEY: '0xdf57089febbacf7ba0bc227dafbffa9fc08a93fdc68e1e42411a14efcf23656e'
+
+# Account #8
+x-relayer_pk: &relayer_pk
+  RELAYER_PRIVATE_KEY: '0xdbda1821b80551c9d65939329250298aa3472ba22feea921c0cf5d620ea67b97'
+
+# Account #18
+x-fast-relayer_pk: &fast-relayer_pk
+  FAST_RELAYER_PRIVATE_KEY: '0xde9be858da4a475276426320d5e9262ecfc3ba460bfac56360bfa6c4c28b4ee0'
+
+
 services:
   gas_oracle:
     depends_on:

--- a/ops/docker-compose.yml
+++ b/ops/docker-compose.yml
@@ -63,10 +63,6 @@
 x-deployer_pk: &deployer_pk
   DEPLOYER_PRIVATE_KEY: '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80'
 
-# Account #19
-x-gas-price-oracle_pk: &gas-price-oracle_pk
-  GAS_PRICE_ORACLE_OWNER_PRIVATE_KEY: '0xdf57089febbacf7ba0bc227dafbffa9fc08a93fdc68e1e42411a14efcf23656e'
-
 # Account #1
 x-sequencer_pk: &sequencer_pk
   SEQUENCER_PRIVATE_KEY: '0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d'


### PR DESCRIPTION
Smaller EC2 instance and missing private keys for the side docker compose.
Cancel all previous integration tests runs because they consume EC2 resources.
Tagging of integration tests is now mandatory (check is done with grep in the linter phase).