### PR TITLE
disable broken DAO Timelock

### DIFF
--- a/integration-tests/test/basic-l1-l2-communication.spec.ts
+++ b/integration-tests/test/basic-l1-l2-communication.spec.ts
@@ -48,7 +48,7 @@ describe('Basic L1<>L2 Communication', async () => {
   })
 
   describe('L2 => L1', () => {
-    it('{tag:other} should be able to perform a withdrawal from L2 -> L1', async function () {
+    it('{tag:boba} should be able to perform a withdrawal from L2 -> L1', async function () {
       await useDynamicTimeoutForWithdrawals(this, env)
 
       const value = `0x${'77'.repeat(32)}`
@@ -75,7 +75,7 @@ describe('Basic L1<>L2 Communication', async () => {
   })
 
   describe('L1 => L2', () => {
-    it('{tag:other} should deposit from L1 -> L2', async () => {
+    it('{tag:boba} should deposit from L1 -> L2', async () => {
       const value = `0x${'42'.repeat(32)}`
 
       // Send L1 -> L2 message.
@@ -97,7 +97,7 @@ describe('Basic L1<>L2 Communication', async () => {
       expect((await L2SimpleStorage.totalCount()).toNumber()).to.equal(1)
     })
 
-    it('{tag:other} should have a receipt with a status of 1 for a successful message', async () => {
+    it('{tag:boba} should have a receipt with a status of 1 for a successful message', async () => {
       const value = `0x${'42'.repeat(32)}`
 
       // Send L1 -> L2 message.

--- a/integration-tests/test/contracts.spec.ts
+++ b/integration-tests/test/contracts.spec.ts
@@ -30,12 +30,12 @@ describe('Contract interactions', () => {
       Factory__ERC20 = await ethers.getContractFactory('ERC20', env.l2Wallet)
     })
 
-    it('{tag:other} should successfully deploy the contract', async () => {
+    it('{tag:boba} should successfully deploy the contract', async () => {
       contract = await Factory__ERC20.deploy(100000000, 'OVM Test', 8, 'OVM')
       await contract.deployed()
     })
 
-    it('{tag:other} should support approvals', async () => {
+    it('{tag:boba} should support approvals', async () => {
       const spender = '0x' + '22'.repeat(20)
       const tx = await contract.approve(spender, 1000)
       await tx.wait()
@@ -54,7 +54,7 @@ describe('Contract interactions', () => {
       expect(logs[0].args._value).to.deep.equal(BigNumber.from(1000))
     })
 
-    it('{tag:other} should support transferring balances', async () => {
+    it('{tag:boba} should support transferring balances', async () => {
       const tx = await contract.transfer(otherWallet.address, 1000)
       await tx.wait()
       const balFrom = await contract.balanceOf(env.l2Wallet.address)
@@ -72,7 +72,7 @@ describe('Contract interactions', () => {
       expect(logs[0].args._value).to.deep.equal(BigNumber.from(1000))
     })
 
-    it('{tag:other} should support being self destructed', async () => {
+    it('{tag:boba} should support being self destructed', async () => {
       const tx = await contract.destroy()
       await tx.wait()
       const code = await env.l2Wallet.provider.getCode(contract.address)

--- a/integration-tests/test/erc20bridge.spec.ts
+++ b/integration-tests/test/erc20bridge.spec.ts
@@ -57,7 +57,7 @@ describe('System setup', async () => {
     )
   })
 
-  it('{tag:other} should use the recently deployed ERC20 TEST token and send some from L1 to L2', async () => {
+  it('{tag:boba} should use the recently deployed ERC20 TEST token and send some from L1 to L2', async () => {
     const preL1ERC20Balance = await L1ERC20.balanceOf(env.l1Wallet.address)
     const preL2ERC20Balance = await L2ERC20.balanceOf(env.l2Wallet.address)
 
@@ -89,7 +89,7 @@ describe('System setup', async () => {
     )
   })
 
-  it('{tag:other} should transfer ERC20 TEST token to Kate', async () => {
+  it('{tag:boba} should transfer ERC20 TEST token to Kate', async () => {
     const transferL2ERC20Amount = utils.parseEther('9')
     await depositERC20ToL2(env.l2Wallet)
     const preKateL2ERC20Balance = await L2ERC20.balanceOf(

--- a/integration-tests/test/erc20turing.spec.ts
+++ b/integration-tests/test/erc20turing.spec.ts
@@ -101,7 +101,7 @@ describe('Turing 256 Bit Random Number Test', async () => {
     ).attach(L1StandardBridgeAddress)
   })
 
-  it('{tag:other} Should transfer BOBA to L2', async () => {
+  it('{tag:boba} Should transfer BOBA to L2', async () => {
     const depositBOBAAmount = utils.parseEther('10')
 
     const preL1BOBABalance = await L1BOBAToken.balanceOf(env.l1Wallet.address)
@@ -136,7 +136,7 @@ describe('Turing 256 Bit Random Number Test', async () => {
     )
   })
 
-  it('{tag:other} contract should be whitelisted', async () => {
+  it('{tag:boba} contract should be whitelisted', async () => {
     const tr2 = await TuringHelper.checkPermittedCaller(random.address)
     const res2 = await tr2.wait()
     const rawData = res2.events[0].data
@@ -148,7 +148,7 @@ describe('Turing 256 Bit Random Number Test', async () => {
     )
   })
 
-  it('{tag:other} Should register and fund your Turing helper contract in turingCredit', async () => {
+  it('{tag:boba} Should register and fund your Turing helper contract in turingCredit', async () => {
     env = await OptimismEnv.new()
 
     const depositAmount = utils.parseEther('0.1')
@@ -180,7 +180,7 @@ describe('Turing 256 Bit Random Number Test', async () => {
     expect(postBalance).to.be.deep.eq(preBalance.add(depositAmount))
   })
 
-  it('{tag:other} should get a 256 bit random number', async () => {
+  it('{tag:boba} should get a 256 bit random number', async () => {
     const tr = await random.getRandom()
     const res = await tr.wait()
     expect(res).to.be.ok

--- a/integration-tests/test/fee-payment.spec.ts
+++ b/integration-tests/test/fee-payment.spec.ts
@@ -32,7 +32,7 @@ describe('Fee Payment Integration Tests', async () => {
     env = await OptimismEnv.new()
   })
 
-  it('{tag:other} should return eth_gasPrice equal to OVM_GasPriceOracle.gasPrice', async () => {
+  it('{tag:boba} should return eth_gasPrice equal to OVM_GasPriceOracle.gasPrice', async () => {
     const assertGasPrice = async () => {
       const gasPrice = await env.l2Wallet.getGasPrice()
       const oracleGasPrice = await env.gasPriceOracle.gasPrice()
@@ -47,7 +47,7 @@ describe('Fee Payment Integration Tests', async () => {
     assertGasPrice()
   })
 
-  it('{tag:other} Paying a nonzero but acceptable gasPrice fee', async () => {
+  it('{tag:boba} Paying a nonzero but acceptable gasPrice fee', async () => {
     await setPrices(env, 1000)
 
     const amount = utils.parseEther('0.0000001')
@@ -91,7 +91,7 @@ describe('Fee Payment Integration Tests', async () => {
     await setPrices(env, 1)
   })
 
-  it('{tag:other} should compute correct fee', async () => {
+  it('{tag:boba} should compute correct fee', async () => {
     await setPrices(env, 1000)
 
     const preBalance = await env.l2Wallet.getBalance()
@@ -136,11 +136,11 @@ describe('Fee Payment Integration Tests', async () => {
     await setPrices(env, 1)
   })
 
-  it('{tag:other} should not be able to withdraw fees before the minimum is met', async () => {
+  it('{tag:boba} should not be able to withdraw fees before the minimum is met', async () => {
     await expect(env.sequencerFeeVault.withdraw()).to.be.rejected
   })
 
-  it('{tag:other} should be able to withdraw fees back to L1 once the minimum is met', async function () {
+  it('{tag:boba} should be able to withdraw fees back to L1 once the minimum is met', async function () {
     const l1FeeWallet = await env.sequencerFeeVault.l1FeeWallet()
     const balanceBefore = await env.l1Wallet.provider.getBalance(l1FeeWallet)
     const withdrawalAmount = await env.sequencerFeeVault.MIN_WITHDRAWAL_AMOUNT()

--- a/integration-tests/test/hardfork.spec.ts
+++ b/integration-tests/test/hardfork.spec.ts
@@ -46,7 +46,7 @@ describe('Hard forks', () => {
   describe('Berlin', () => {
     // https://eips.ethereum.org/EIPS/eip-2929
     describe('EIP-2929', () => {
-      it('{tag:other} should update the gas schedule', async () => {
+      it('{tag:boba} should update the gas schedule', async () => {
         // Get the tip height
         const tip = await env.l2Provider.getBlock('latest')
 
@@ -81,7 +81,7 @@ describe('Hard forks', () => {
 
     // https://eips.ethereum.org/EIPS/eip-2565
     describe('EIP-2565', async () => {
-      it('{tag:other} should become cheaper', async () => {
+      it('{tag:boba} should become cheaper', async () => {
         const tip = await env.l2Provider.getBlock('latest')
 
         const tx = await Precompiles.expmod(64, 1, 64, { gasLimit: 5_000_000 })
@@ -111,7 +111,7 @@ describe('Hard forks', () => {
       const bytes32Zero = '0x' + '00'.repeat(32)
       const bytes32NonZero = '0x' + 'ff'.repeat(32)
 
-      it('{tag:other} should lower the refund for storage clear', async () => {
+      it('{tag:boba} should lower the refund for storage clear', async () => {
         const tip = await env.l2Provider.getBlock('latest')
 
         const value = await SelfDestruction.callStatic.data()
@@ -183,7 +183,7 @@ describe('Hard forks', () => {
         }
       })
 
-      it('{tag:other} should remove the refund for selfdestruct', async () => {
+      it('{tag:boba} should remove the refund for selfdestruct', async () => {
         const tip = await env.l2Provider.getBlock('latest')
 
         // Send transaction with a large gas limit

--- a/integration-tests/test/mrf_lp.spec.ts
+++ b/integration-tests/test/mrf_lp.spec.ts
@@ -141,7 +141,7 @@ describe('Liquidity Pool Test', async () => {
     )
   })
 
-  it('{tag:mrf} should deposit 10000 TEST ERC20 token from L1 to L2', async () => {
+  it('{tag:boba} should deposit 10000 TEST ERC20 token from L1 to L2', async () => {
     const depositL2ERC20Amount = utils.parseEther('10000')
 
     const preL1ERC20Balance = await L1ERC20.balanceOf(env.l1Wallet.address)
@@ -176,7 +176,7 @@ describe('Liquidity Pool Test', async () => {
     )
   })
 
-  it('{tag:mrf} should transfer L2 ERC20 TEST token from Bob to Alice and Kate', async () => {
+  it('{tag:boba} should transfer L2 ERC20 TEST token from Bob to Alice and Kate', async () => {
     const transferL2ERC20Amount = utils.parseEther('150')
 
     const preBobL2ERC20Balance = await L2ERC20.balanceOf(env.l2Wallet.address)
@@ -224,7 +224,7 @@ describe('Liquidity Pool Test', async () => {
     )
   })
 
-  it('{tag:mrf} should add 1000 ERC20 TEST tokens to the L2 token pool', async () => {
+  it('{tag:boba} should add 1000 ERC20 TEST tokens to the L2 token pool', async () => {
     const addL2TPAmount = utils.parseEther('1000')
 
     const approveL2TPTX = await L2ERC20.approve(
@@ -246,7 +246,7 @@ describe('Liquidity Pool Test', async () => {
     expect(L2TPBalance).to.deep.eq(addL2TPAmount)
   })
 
-  it('{tag:mrf} should register L1 the pool', async () => {
+  it('{tag:boba} should register L1 the pool', async () => {
     const registerPoolERC20TX = await L1LiquidityPool.registerPool(
       L1ERC20.address,
       L2ERC20.address
@@ -269,7 +269,7 @@ describe('Liquidity Pool Test', async () => {
     expect(poolETHInfo.l2TokenAddress).to.deep.eq(env.ovmEth.address)
   })
 
-  it('{tag:mrf} should register L2 the pool', async () => {
+  it('{tag:boba} should register L2 the pool', async () => {
     const registerPoolERC20TX = await L2LiquidityPool.registerPool(
       L1ERC20.address,
       L2ERC20.address
@@ -289,7 +289,7 @@ describe('Liquidity Pool Test', async () => {
     expect(poolETHInfo.l2TokenAddress).to.deep.eq(env.ovmEth.address)
   })
 
-  it('{tag:mrf} shouldnt update the pool', async () => {
+  it('{tag:boba} shouldnt update the pool', async () => {
     const registerPoolTX = await L2LiquidityPool.registerPool(
       L1ERC20.address,
       L2ERC20.address,
@@ -298,7 +298,7 @@ describe('Liquidity Pool Test', async () => {
     await expect(registerPoolTX.wait()).to.be.eventually.rejected
   })
 
-  it('{tag:mrf} should add L1 liquidity', async () => {
+  it('{tag:boba} should add L1 liquidity', async () => {
     const addLiquidityAmount = utils.parseEther('100')
 
     const preBobL1ERC20Balance = await L1ERC20.balanceOf(env.l1Wallet.address)
@@ -328,7 +328,7 @@ describe('Liquidity Pool Test', async () => {
     expect(L1LPERC20Balance).to.deep.eq(addLiquidityAmount)
   })
 
-  it('{tag:mrf} should add L2 liquidity', async () => {
+  it('{tag:boba} should add L2 liquidity', async () => {
     const addLiquidityAmount = utils.parseEther('100')
 
     const preBobL2ERC20Balance = await L2ERC20.balanceOf(env.l2Wallet.address)
@@ -394,7 +394,7 @@ describe('Liquidity Pool Test', async () => {
     expect(L2LPERC20Balance).to.deep.eq(addLiquidityAmount.mul(2))
   })
 
-  it('{tag:mrf} should fast exit L2', async () => {
+  it('{tag:boba} should fast exit L2', async () => {
     const fastExitAmount = utils.parseEther('10')
 
     const preKateL1ERC20Balance = await L1ERC20.balanceOf(
@@ -492,7 +492,7 @@ describe('Liquidity Pool Test', async () => {
     )
   })
 
-  it('{tag:mrf} should withdraw liquidity', async () => {
+  it('{tag:boba} should withdraw liquidity', async () => {
     const withdrawAmount = utils.parseEther('10')
 
     const preBobL2ERC20Balance = await L2ERC20.balanceOf(env.l2Wallet.address)
@@ -538,7 +538,7 @@ describe('Liquidity Pool Test', async () => {
     )
   })
 
-  it('{tag:mrf} shouldnt withdraw liquidity', async () => {
+  it('{tag:boba} shouldnt withdraw liquidity', async () => {
     const withdrawAmount = utils.parseEther('100')
 
     const withdrawTX = await L2LiquidityPool.withdrawLiquidity(
@@ -550,7 +550,7 @@ describe('Liquidity Pool Test', async () => {
     await expect(withdrawTX.wait()).to.be.eventually.rejected
   })
 
-  it('{tag:mrf} should withdraw reward from L2 pool', async () => {
+  it('{tag:boba} should withdraw reward from L2 pool', async () => {
     const preL2ERC20Balance = await L2ERC20.balanceOf(env.l2Wallet.address)
     const preBobUserInfo = await L2LiquidityPool.userInfo(
       L2ERC20.address,
@@ -579,7 +579,7 @@ describe('Liquidity Pool Test', async () => {
     expect(preL2ERC20Balance).to.deep.eq(postL2ERC20Balance.sub(pendingReward))
   })
 
-  it('{tag:mrf} should withdraw reward from L1 pool', async () => {
+  it('{tag:boba} should withdraw reward from L1 pool', async () => {
     const preL1ERC20Balance = await L1ERC20.balanceOf(env.l1Wallet.address)
     const preBobUserInfo = await L1LiquidityPool.userInfo(
       L1ERC20.address,
@@ -612,7 +612,7 @@ describe('Liquidity Pool Test', async () => {
     expect(preL1ERC20Balance).to.deep.eq(postL1ERC20Balance.sub(pendingReward))
   })
 
-  it('{tag:mrf} shouldnt withdraw reward from L2 pool', async () => {
+  it('{tag:boba} shouldnt withdraw reward from L2 pool', async () => {
     const withdrawRewardAmount = utils.parseEther('100')
 
     const withdrawRewardTX = await L2LiquidityPool.withdrawReward(
@@ -624,7 +624,7 @@ describe('Liquidity Pool Test', async () => {
     await expect(withdrawRewardTX.wait()).to.be.eventually.rejected
   })
 
-  it('{tag:mrf} should fast onramp', async () => {
+  it('{tag:boba} should fast onramp', async () => {
     const depositAmount = utils.parseEther('10')
 
     const preL2ERC20Balance = await L2ERC20.balanceOf(env.l2Wallet.address)
@@ -701,7 +701,7 @@ describe('Liquidity Pool Test', async () => {
     )
   })
 
-  it('{tag:mrf} should revert unfulfillable swap-offs', async () => {
+  it('{tag:boba} should revert unfulfillable swap-offs', async () => {
     const preBobL2ERC20Balance = await L2ERC20.balanceOf(env.l2Wallet.address)
     const preBobL1ERC20Balance = await L1ERC20.balanceOf(env.l1Wallet.address)
 
@@ -745,7 +745,7 @@ describe('Liquidity Pool Test', async () => {
     expect(postBobL2ERC20Balance).to.deep.eq(preBobL2ERC20Balance.sub(exitFees))
   })
 
-  it('{tag:mrf} should revert unfulfillable swap-ons', async () => {
+  it('{tag:boba} should revert unfulfillable swap-ons', async () => {
     const preL2ERC20Balance = await L2ERC20.balanceOf(env.l2Wallet.address)
     const preL1ERC20Balance = await L1ERC20.balanceOf(env.l1Wallet.address)
 
@@ -784,7 +784,7 @@ describe('Liquidity Pool Test', async () => {
     expect(postBobL1ERC20Balance).to.deep.eq(preL1ERC20Balance.sub(swapOnFees))
   })
 
-  it('{tag:mrf} Should rebalance ERC20 from L1 to L2', async () => {
+  it('{tag:boba} Should rebalance ERC20 from L1 to L2', async () => {
     const balanceERC20Amount = utils.parseEther('10')
 
     const preLPL1ERC20Balance = await L1ERC20.balanceOf(L1LiquidityPool.address)
@@ -810,7 +810,7 @@ describe('Liquidity Pool Test', async () => {
     )
   })
 
-  it('{tag:mrf} Should rebalance ERC20 from L2 to L1', async () => {
+  it('{tag:boba} Should rebalance ERC20 from L2 to L1', async () => {
     const balanceERC20Amount = utils.parseEther('10')
 
     const preLPL1ERC20Balance = await L1ERC20.balanceOf(L1LiquidityPool.address)
@@ -836,7 +836,7 @@ describe('Liquidity Pool Test', async () => {
     )
   })
 
-  it('{tag:mrf} Should revert rebalancing LP', async () => {
+  it('{tag:boba} Should revert rebalancing LP', async () => {
     const balanceERC20Amount = utils.parseEther('10000')
 
     await expect(
@@ -924,7 +924,7 @@ describe('Liquidity Pool Test', async () => {
     await AddLiquidity.wait()
   })
 
-  it('{tag:mrf} Should rebalance OMGLikeToken from L1 to L2', async () => {
+  it('{tag:boba} Should rebalance OMGLikeToken from L1 to L2', async () => {
     const balanceERC20Amount = utils.parseEther('10')
 
     const preLPL1ERC20Balance = await OMGLIkeToken.balanceOf(
@@ -961,7 +961,7 @@ describe('Liquidity Pool Test', async () => {
     expect(L1LPOMGLikeTokenAllowance).to.deep.eq(BigNumber.from(0))
   })
 
-  it('{tag:mrf} Should rebalance OMGLikeToken from L2 to L1', async () => {
+  it('{tag:boba} Should rebalance OMGLikeToken from L2 to L1', async () => {
     const balanceERC20Amount = utils.parseEther('10')
 
     const preLPL1ERC20Balance = await OMGLIkeToken.balanceOf(
@@ -991,7 +991,7 @@ describe('Liquidity Pool Test', async () => {
     )
   })
 
-  it('{tag:mrf} should be able to pause L1LiquidityPool contract', async function () {
+  it('{tag:boba} should be able to pause L1LiquidityPool contract', async function () {
     const poolOwner = await L1LiquidityPool.owner()
 
     // since tests are with deployed contracts
@@ -1038,7 +1038,7 @@ describe('Liquidity Pool Test', async () => {
     }
   })
 
-  it('{tag:mrf} should be able to pause L2LiquidityPool contract', async function () {
+  it('{tag:boba} should be able to pause L2LiquidityPool contract', async function () {
     const poolOwner = await L2LiquidityPool.owner()
 
     // since tests are with deployed contracts
@@ -1085,7 +1085,7 @@ describe('Liquidity Pool Test', async () => {
     }
   })
 
-  it('{tag:mrf} the DAO should be able to configure fee for L2LP', async function () {
+  it('{tag:boba} the DAO should be able to configure fee for L2LP', async function () {
     // admin will be set to the DAO/timelock in the future
     const poolAdmin = await L2LiquidityPool.DAO()
 
@@ -1133,13 +1133,13 @@ describe('Liquidity Pool Test', async () => {
     }
   })
 
-  it('{tag:mrf} should fail configuring L2LP fee for non DAO', async () => {
+  it('{tag:boba} should fail configuring L2LP fee for non DAO', async () => {
     await expect(
       L2LiquidityPool.connect(env.l2Wallet_2).configureFee(5, 35, 15)
     ).to.be.revertedWith('Caller is not the DAO')
   })
 
-  it('{tag:mrf} the DAO should be able to configure fee for L1LP', async function () {
+  it('{tag:boba} the DAO should be able to configure fee for L1LP', async function () {
     // admin will be set to the DAO timelock in the future
     const poolAdmin = await L2LiquidityPool.DAO()
 
@@ -1193,7 +1193,7 @@ describe('Liquidity Pool Test', async () => {
     }
   })
 
-  it('{tag:mrf} should fail configuring L1LP fee for non DAO', async () => {
+  it('{tag:boba} should fail configuring L1LP fee for non DAO', async () => {
     await expect(
       L2LiquidityPool.connect(env.l2Wallet_2).configureFeeExits(5, 35, 15)
     ).to.be.revertedWith('Caller is not the DAO')
@@ -1204,7 +1204,7 @@ describe('Liquidity Pool Test', async () => {
   })
 
   describe('OVM_ETH tests', async () => {
-    it('{tag:mrf} should add L1 liquidity', async () => {
+    it('{tag:boba} should add L1 liquidity', async () => {
       const addLiquidityAmount = utils.parseEther('100')
 
       const preL1LPEthBalance = await env.l1Provider.getBalance(
@@ -1228,7 +1228,7 @@ describe('Liquidity Pool Test', async () => {
       )
     })
 
-    it('{tag:mrf} should add L2 liquidity', async () => {
+    it('{tag:boba} should add L2 liquidity', async () => {
       const addLiquidityAmount = utils.parseEther('100')
 
       const deposit = env.l1Bridge.depositETH(
@@ -1277,7 +1277,7 @@ describe('Liquidity Pool Test', async () => {
       )
     })
 
-    it('{tag:mrf} should fail to fast exit L2 with incorrect inputs', async () => {
+    it('{tag:boba} should fail to fast exit L2 with incorrect inputs', async () => {
       const fastExitAmount = utils.parseEther('10')
 
       await expect(
@@ -1297,7 +1297,7 @@ describe('Liquidity Pool Test', async () => {
       ).to.be.revertedWith('Either Amount Incorrect or Token Address Incorrect')
     })
 
-    it('{tag:mrf} should fast exit L2', async () => {
+    it('{tag:boba} should fast exit L2', async () => {
       const fastExitAmount = utils.parseEther('10')
 
       const prebobL1EthBalance = await env.l1Wallet.getBalance()
@@ -1358,7 +1358,7 @@ describe('Liquidity Pool Test', async () => {
       )
     })
 
-    it('{tag:mrf} Should rebalance ETH from L1 to L2', async () => {
+    it('{tag:boba} Should rebalance ETH from L1 to L2', async () => {
       const balanceETHAmount = utils.parseEther('10')
 
       const preL1LPETH = await env.l1Provider.getBalance(
@@ -1387,7 +1387,7 @@ describe('Liquidity Pool Test', async () => {
       expect(preL2LPETH).to.deep.eq(postL2LPETH.sub(balanceETHAmount))
     })
 
-    it('{tag:mrf} Should rebalance ETH from L2 to L1', async () => {
+    it('{tag:boba} Should rebalance ETH from L2 to L1', async () => {
       const balanceETHAmount = utils.parseEther('1')
 
       const preL1LPETH = await env.l1Provider.getBalance(
@@ -1416,7 +1416,7 @@ describe('Liquidity Pool Test', async () => {
       expect(preL2LPETH).to.deep.eq(postL2LPETH.add(balanceETHAmount))
     })
 
-    it('{tag:mrf} Should revert rebalancing LP', async () => {
+    it('{tag:boba} Should revert rebalancing LP', async () => {
       const balanceETHAmount = utils.parseEther('10000')
 
       await expect(
@@ -1448,7 +1448,7 @@ describe('Liquidity Pool Test', async () => {
       ).to.be.reverted
     })
 
-    it('{tag:mrf} should withdraw liquidity', async () => {
+    it('{tag:boba} should withdraw liquidity', async () => {
       const withdrawAmount = utils.parseEther('10')
 
       const preBobUserInfo = await L2LiquidityPool.userInfo(
@@ -1474,7 +1474,7 @@ describe('Liquidity Pool Test', async () => {
       )
     })
 
-    it('{tag:mrf} should withdraw reward from L2 pool', async () => {
+    it('{tag:boba} should withdraw reward from L2 pool', async () => {
       const preBobUserInfo = await L2LiquidityPool.userInfo(
         env.ovmEth.address,
         env.l2Wallet.address
@@ -1500,7 +1500,7 @@ describe('Liquidity Pool Test', async () => {
       )
     })
 
-    it('{tag:mrf} should fail to fast onramp with incorrect inputs', async () => {
+    it('{tag:boba} should fail to fast onramp with incorrect inputs', async () => {
       const depositAmount = utils.parseEther('10')
 
       await expect(
@@ -1520,7 +1520,7 @@ describe('Liquidity Pool Test', async () => {
       ).to.be.revertedWith('Either Amount Incorrect or Token Address Incorrect')
     })
 
-    it('{tag:mrf} should fast onramp', async () => {
+    it('{tag:boba} should fast onramp', async () => {
       const depositAmount = utils.parseEther('10')
 
       const preL2EthBalance = await env.l2Wallet.getBalance()
@@ -1578,7 +1578,7 @@ describe('Liquidity Pool Test', async () => {
       )
     })
 
-    it('{tag:mrf} should revert unfulfillable swap-offs', async () => {
+    it('{tag:boba} should revert unfulfillable swap-offs', async () => {
       const userRewardFeeRate = await L2LiquidityPool.getUserRewardFeeRate(
         env.ovmEth.address
       )
@@ -1606,7 +1606,7 @@ describe('Liquidity Pool Test', async () => {
       expect(preBobL1EthBalance).to.deep.eq(postBobL1EthBalance)
     })
 
-    it('{tag:mrf} should revert unfulfillable swap-ons', async () => {
+    it('{tag:boba} should revert unfulfillable swap-ons', async () => {
       const userRewardFeeRate = await L1LiquidityPool.getUserRewardFeeRate(
         ethers.constants.AddressZero
       )
@@ -1639,7 +1639,7 @@ describe('Liquidity Pool Test', async () => {
   })
 
   describe('Relay gas burn tests', async () => {
-    it('{tag:mrf} should not allow updating extraGasRelay for non-owner', async () => {
+    it('{tag:boba} should not allow updating extraGasRelay for non-owner', async () => {
       const newExtraGasRelay = 500000
       await expect(
         L2LiquidityPool.connect(env.l2Wallet_2).configureExtraGasRelay(
@@ -1648,7 +1648,7 @@ describe('Liquidity Pool Test', async () => {
       ).to.be.revertedWith('Caller is not the gasPriceOracle owner')
     })
 
-    it('{tag:mrf} should allow updating extraGasRelay for owner', async () => {
+    it('{tag:boba} should allow updating extraGasRelay for owner', async () => {
       // approximate and set new extra gas to over it for tests
       const approveBobL2TX = await L2ERC20.approve(
         L2LiquidityPool.address,
@@ -1670,7 +1670,7 @@ describe('Liquidity Pool Test', async () => {
       expect(updatedExtraGasRelay).to.eq(newExtraGasRelay)
     })
 
-    it('{tag:mrf} should be able to fast exit with correct added gas', async () => {
+    it('{tag:boba} should be able to fast exit with correct added gas', async () => {
       const fastExitAmount = utils.parseEther('10')
 
       const preBobL1ERC20Balance = await L1ERC20.balanceOf(env.l1Wallet.address)
@@ -1754,7 +1754,7 @@ describe('Liquidity Pool Test', async () => {
       )
     })
 
-    it('{tag:mrf} Should mint xBOBA', async () => {
+    it('{tag:boba} Should mint xBOBA', async () => {
       const depositAmount = utils.parseEther('10')
 
       const prexBOBAAmount = await xBOBAToken.balanceOf(env.l2Wallet.address)
@@ -1776,7 +1776,7 @@ describe('Liquidity Pool Test', async () => {
       expect(prexBOBAAmount).to.deep.eq(postxBOBAAmount.sub(depositAmount))
     })
 
-    it('{tag:mrf} Should burn xBOBA', async () => {
+    it('{tag:boba} Should burn xBOBA', async () => {
       const exitAmount = utils.parseEther('5')
 
       const prexBOBAAmount = await xBOBAToken.balanceOf(env.l2Wallet.address)
@@ -1889,7 +1889,7 @@ describe('Liquidity Pool Test', async () => {
       ;[L1ERC20_3, L2ERC20_3] = await createTokenPair()
     })
 
-    it('{tag:mrf} should deposit ERC20', async () => {
+    it('{tag:boba} should deposit ERC20', async () => {
       const depositAmount = utils.parseEther('10')
 
       const preL1ERC20Balance = await L1ERC20_1.balanceOf(env.l1Wallet.address)
@@ -1930,7 +1930,7 @@ describe('Liquidity Pool Test', async () => {
       )
     })
 
-    it('{tag:mrf} should not deposit ERC20 for an unregistered token', async () => {
+    it('{tag:boba} should not deposit ERC20 for an unregistered token', async () => {
       const depositAmount = utils.parseEther('10')
       const L1ERC20Test = await Factory__L1ERC20.deploy(
         initialSupply,
@@ -1959,7 +1959,7 @@ describe('Liquidity Pool Test', async () => {
       ).to.be.revertedWith('Invaild Token')
     })
 
-    it('{tag:mrf} should deposit ETH', async () => {
+    it('{tag:boba} should deposit ETH', async () => {
       const depositAmount = utils.parseEther('10')
 
       const preL2ETHBalance = await env.l2Wallet.getBalance()
@@ -1989,7 +1989,7 @@ describe('Liquidity Pool Test', async () => {
       )
     })
 
-    it('{tag:mrf} should not deposit ETH for the wrong payload', async () => {
+    it('{tag:boba} should not deposit ETH for the wrong payload', async () => {
       const depositAmount = utils.parseEther('10')
       const depositAmountMismatch = utils.parseEther('9')
 
@@ -2006,7 +2006,7 @@ describe('Liquidity Pool Test', async () => {
       ).to.be.revertedWith('Invalid ETH Amount')
     })
 
-    it('{tag:mrf} should depoist ETH and ERC20 together', async () => {
+    it('{tag:boba} should depoist ETH and ERC20 together', async () => {
       const depositAmount = utils.parseEther('10')
 
       const preL1ERC20Balance = await L1ERC20_1.balanceOf(env.l1Wallet.address)
@@ -2063,7 +2063,7 @@ describe('Liquidity Pool Test', async () => {
       )
     })
 
-    it('{tag:mrf} should not deposit ETH and ERC20 together for the wrong payload', async () => {
+    it('{tag:boba} should not deposit ETH and ERC20 together for the wrong payload', async () => {
       const depositAmount = utils.parseEther('10')
       const depositAmountMismatch = utils.parseEther('9')
 
@@ -2128,7 +2128,7 @@ describe('Liquidity Pool Test', async () => {
       ).to.be.revertedWith('Invalid Amount')
     })
 
-    it('{tag:mrf} should deposit ETH and three ERC20 together', async () => {
+    it('{tag:boba} should deposit ETH and three ERC20 together', async () => {
       const depositAmount = utils.parseEther('10')
 
       await approveTransaction(
@@ -2254,7 +2254,7 @@ describe('Liquidity Pool Test', async () => {
       )
     })
 
-    it('{tag:mrf} should not deposit ETH and ERC20 for too large payload', async () => {
+    it('{tag:boba} should not deposit ETH and ERC20 for too large payload', async () => {
       const depositAmount = utils.parseEther('10')
 
       await approveTransaction(
@@ -2290,7 +2290,7 @@ describe('Liquidity Pool Test', async () => {
       ).to.be.revertedWith('Too Many Tokens')
     })
 
-    it('{tag:mrf} should deposit ERC20 twice in batch', async () => {
+    it('{tag:boba} should deposit ERC20 twice in batch', async () => {
       const depositAmount = utils.parseEther('10')
 
       const preL1ERC20Balance = await L1ERC20_1.balanceOf(env.l1Wallet.address)
@@ -2330,7 +2330,7 @@ describe('Liquidity Pool Test', async () => {
       )
     })
 
-    it('{tag:mrf} should deposit ETH twice in batch', async () => {
+    it('{tag:boba} should deposit ETH twice in batch', async () => {
       const depositAmount = utils.parseEther('10')
 
       const preL2ETHBalance = await env.l2Wallet.getBalance()
@@ -2367,7 +2367,7 @@ describe('Liquidity Pool Test', async () => {
       )
     })
 
-    it('{tag:mrf} should revert an unfulfillable swap-on', async () => {
+    it('{tag:boba} should revert an unfulfillable swap-on', async () => {
       const userRewardFeeRate = await L1LiquidityPool.getUserRewardFeeRate(
         ethers.constants.AddressZero
       )
@@ -2398,7 +2398,7 @@ describe('Liquidity Pool Test', async () => {
       expect(preL2EthBalance).to.deep.eq(postBobL2EthBalance)
     })
 
-    it('{tag:mrf} should revert an unfulfillable swap-on in batch', async () => {
+    it('{tag:boba} should revert an unfulfillable swap-on in batch', async () => {
       const depositAmount = utils.parseEther('10')
 
       await approveTransaction(
@@ -2452,7 +2452,7 @@ describe('Liquidity Pool Test', async () => {
       )
     })
 
-    it('{tag:mrf} should revert unfulfillable swap-ons in batch', async () => {
+    it('{tag:boba} should revert unfulfillable swap-ons in batch', async () => {
       const depositAmount = utils.parseEther('10')
 
       await approveTransaction(

--- a/integration-tests/test/mrf_message.spec.ts
+++ b/integration-tests/test/mrf_message.spec.ts
@@ -32,14 +32,14 @@ describe('Fast Messenge Relayer Test', async () => {
     )
   })
 
-  it('{tag:mrf} should send message from L1 to L2', async () => {
+  it('{tag:boba} should send message from L1 to L2', async () => {
     await env.waitForXDomainTransaction(
       L1Message.sendMessageL1ToL2(),
       Direction.L1ToL2
     )
   })
 
-  it('{tag:mrf} should QUICKLY send message from L2 to L1 using the fast relayer', async () => {
+  it('{tag:boba} should QUICKLY send message from L2 to L1 using the fast relayer', async () => {
     await env.waitForXDomainTransactionFast(
       L2Message.sendMessageL2ToL1({ gasLimit: 800000, gasPrice: 0 }),
       Direction.L2ToL1

--- a/integration-tests/test/native-eth-ovm-calls.spec.ts
+++ b/integration-tests/test/native-eth-ovm-calls.spec.ts
@@ -24,7 +24,7 @@ describe('Native ETH value integration tests', () => {
     other = Wallet.createRandom().connect(wallet.provider)
   })
 
-  it('{tag:other} should allow an L2 EOA to send to a new account and back again', async () => {
+  it('{tag:boba} should allow an L2 EOA to send to a new account and back again', async () => {
     const getBalances = async (): Promise<BigNumber[]> => {
       return [
         await wallet.provider.getBalance(wallet.address),
@@ -152,7 +152,7 @@ describe('Native ETH value integration tests', () => {
       await checkBalances([initialBalance0, 0])
     })
 
-    it('{tag:other} should allow ETH to be sent', async () => {
+    it('{tag:boba} should allow ETH to be sent', async () => {
       const sendAmount = 15
       const tx = await ValueCalls0.simpleSend(ValueCalls1.address, sendAmount, {
         gasPrice: 0,
@@ -162,7 +162,7 @@ describe('Native ETH value integration tests', () => {
       await checkBalances([initialBalance0 - sendAmount, sendAmount])
     })
 
-    it('{tag:other} should revert if a function is nonpayable', async () => {
+    it('{tag:boba} should revert if a function is nonpayable', async () => {
       const sendAmount = 15
       const [success, returndata] = await ValueCalls0.callStatic.sendWithData(
         ValueCalls1.address,
@@ -174,7 +174,7 @@ describe('Native ETH value integration tests', () => {
       expect(returndata).to.eq('0x')
     })
 
-    it('{tag:other} should allow ETH to be sent and have the correct ovmCALLVALUE', async () => {
+    it('{tag:boba} should allow ETH to be sent and have the correct ovmCALLVALUE', async () => {
       const sendAmount = 15
       const [success, returndata] = await ValueCalls0.callStatic.sendWithData(
         ValueCalls1.address,
@@ -186,7 +186,7 @@ describe('Native ETH value integration tests', () => {
       expect(BigNumber.from(returndata)).to.deep.eq(BigNumber.from(sendAmount))
     })
 
-    it('{tag:other} should have the correct ovmSELFBALANCE which includes the msg.value', async () => {
+    it('{tag:boba} should have the correct ovmSELFBALANCE which includes the msg.value', async () => {
       // give an initial balance which the ovmCALLVALUE should be added to when calculating ovmSELFBALANCE
       const initialBalance = 10
       await fundUser(
@@ -209,7 +209,7 @@ describe('Native ETH value integration tests', () => {
       )
     })
 
-    it('{tag:other} should have the correct callvalue but not persist the transfer if the target reverts', async () => {
+    it('{tag:boba} should have the correct callvalue but not persist the transfer if the target reverts', async () => {
       const sendAmount = 15
       const internalCalldata = ValueCalls1.interface.encodeFunctionData(
         'verifyCallValueAndRevert',
@@ -227,7 +227,7 @@ describe('Native ETH value integration tests', () => {
       await checkBalances([initialBalance0, 0])
     })
 
-    it('{tag:other} should look like the subcall reverts with no data if value exceeds balance', async () => {
+    it('{tag:boba} should look like the subcall reverts with no data if value exceeds balance', async () => {
       const sendAmount = initialBalance0 + 1
       const internalCalldata = ValueCalls1.interface.encodeFunctionData(
         'verifyCallValueAndReturn',
@@ -243,7 +243,7 @@ describe('Native ETH value integration tests', () => {
       expect(returndata).to.eq('0x')
     })
 
-    it('{tag:other} should preserve msg.value through ovmDELEGATECALLs', async () => {
+    it('{tag:boba} should preserve msg.value through ovmDELEGATECALLs', async () => {
       const Factory__ValueContext = await ethers.getContractFactory(
         'ValueContext',
         wallet
@@ -276,7 +276,7 @@ describe('Native ETH value integration tests', () => {
       expect(delegatedOvmCALLVALUE).to.deep.eq(BigNumber.from(sendAmount))
     })
 
-    it('{tag:other} should have correct address(this).balance through ovmDELEGATECALLs to another account', async () => {
+    it('{tag:boba} should have correct address(this).balance through ovmDELEGATECALLs to another account', async () => {
       const Factory__ValueContext = await ethers.getContractFactory(
         'ValueContext',
         wallet
@@ -293,7 +293,7 @@ describe('Native ETH value integration tests', () => {
       expect(delegatedReturndata).to.deep.eq(BigNumber.from(initialBalance0))
     })
 
-    it('{tag:other} should have correct address(this).balance through ovmDELEGATECALLs to same account', async () => {
+    it('{tag:boba} should have correct address(this).balance through ovmDELEGATECALLs to same account', async () => {
       const [delegatedSuccess, delegatedReturndata] =
         await ValueCalls0.callStatic.delegateCallToAddressThisBalance(
           ValueCalls0.address
@@ -303,7 +303,7 @@ describe('Native ETH value integration tests', () => {
       expect(delegatedReturndata).to.deep.eq(BigNumber.from(initialBalance0))
     })
 
-    it('{tag:other} should allow delegate calls which preserve msg.value even with no balance going into the inner call', async () => {
+    it('{tag:boba} should allow delegate calls which preserve msg.value even with no balance going into the inner call', async () => {
       const Factory__SendETHAwayAndDelegateCall: ContractFactory =
         await ethers.getContractFactory('SendETHAwayAndDelegateCall', wallet)
       const SendETHAwayAndDelegateCall: Contract =

--- a/integration-tests/test/native-eth.spec.ts
+++ b/integration-tests/test/native-eth.spec.ts
@@ -53,7 +53,7 @@ describe('Native ETH Integration Tests', async () => {
   })
 
   describe('estimateGas', () => {
-    it('{tag:other} Should estimate gas for ETH withdraw', async () => {
+    it('{tag:boba} Should estimate gas for ETH withdraw', async () => {
       const amount = utils.parseEther('0.0000001')
       const gas = await env.l2Bridge.estimateGas.withdraw(
         predeploys.OVM_ETH,
@@ -66,7 +66,7 @@ describe('Native ETH Integration Tests', async () => {
     })
   })
 
-  it('{tag:other} receive', async () => {
+  it('{tag:boba} receive', async () => {
     const depositAmount = 10
     const preBalances = await getBalances(env)
     const { tx, receipt } = await env.waitForXDomainTransaction(
@@ -92,7 +92,7 @@ describe('Native ETH Integration Tests', async () => {
     )
   })
 
-  it('{tag:other} depositETH', async () => {
+  it('{tag:boba} depositETH', async () => {
     const depositAmount = 10
     const preBalances = await getBalances(env)
     const { tx, receipt } = await env.waitForXDomainTransaction(
@@ -117,7 +117,7 @@ describe('Native ETH Integration Tests', async () => {
     )
   })
 
-  it('{tag:other} depositETHTo', async () => {
+  it('{tag:boba} depositETHTo', async () => {
     const depositAmount = 10
     const preBalances = await getBalances(env)
     const depositReceipts = await env.waitForXDomainTransaction(
@@ -143,7 +143,7 @@ describe('Native ETH Integration Tests', async () => {
     )
   })
 
-  it('{tag:other} deposit passes with a large data argument', async () => {
+  it('{tag:boba} deposit passes with a large data argument', async () => {
     const ASSUMED_L2_GAS_LIMIT = 8_000_000
     const depositAmount = 10
     const preBalances = await getBalances(env)
@@ -172,7 +172,7 @@ describe('Native ETH Integration Tests', async () => {
     )
   })
 
-  it('{tag:other} depositETH fails with a TOO large data argument', async () => {
+  it('{tag:boba} depositETH fails with a TOO large data argument', async () => {
     const depositAmount = 10
 
     const data = `0x` + 'ab'.repeat(MAX_ROLLUP_TX_SIZE + 1)
@@ -183,7 +183,7 @@ describe('Native ETH Integration Tests', async () => {
     ).to.be.reverted
   })
 
-  it('{tag:other} withdraw', async function () {
+  it('{tag:boba} withdraw', async function () {
     await useDynamicTimeoutForWithdrawals(this, env)
 
     const withdrawAmount = BigNumber.from(3)
@@ -227,7 +227,7 @@ describe('Native ETH Integration Tests', async () => {
     )
   })
 
-  it('{tag:other} withdrawTo', async function () {
+  it('{tag:boba} withdrawTo', async function () {
     await useDynamicTimeoutForWithdrawals(this, env)
 
     const withdrawAmount = BigNumber.from(3)
@@ -284,7 +284,7 @@ describe('Native ETH Integration Tests', async () => {
     )
   })
 
-  it('{tag:other} deposit, transfer, withdraw', async function () {
+  it('{tag:boba} deposit, transfer, withdraw', async function () {
     await useDynamicTimeoutForWithdrawals(this, env)
 
     // 1. deposit

--- a/integration-tests/test/ovmcontext.spec.ts
+++ b/integration-tests/test/ovmcontext.spec.ts
@@ -42,7 +42,7 @@ describe('OVM Context: Layer 2 EVM Context', () => {
 
   const numTxs = 5
 
-  it('{tag:other} enqueue: L1 contextual values are correctly set in L2', async () => {
+  it('{tag:boba} enqueue: L1 contextual values are correctly set in L2', async () => {
     for (let i = 0; i < numTxs; i++) {
       // Send a transaction from L1 to L2. This will automatically update the L1 contextual
       // information like the L1 block number and L1 timestamp.
@@ -89,7 +89,7 @@ describe('OVM Context: Layer 2 EVM Context', () => {
     }
   }).timeout(150000) // this specific test takes a while because it involves L1 to L2 txs
 
-  it('{tag:other} should set correct OVM Context for `eth_call`', async () => {
+  it('{tag:boba} should set correct OVM Context for `eth_call`', async () => {
     for (let i = 0; i < numTxs; i++) {
       // Make an empty transaction to bump the latest block number.
       const dummyTx = await env.l2Wallet.sendTransaction({
@@ -138,7 +138,7 @@ describe('OVM Context: Layer 2 EVM Context', () => {
    * OVM context.
    */
 
-  it('{tag:other} should return same timestamp and blocknumbers between `eth_call` and `rollup_getInfo`', async () => {
+  it('{tag:boba} should return same timestamp and blocknumbers between `eth_call` and `rollup_getInfo`', async () => {
     // As atomically as possible, call `rollup_getInfo` and OVMMulticall for the
     // blocknumber and timestamp. If this is not atomic, then the sequencer can
     // happend to update the timestamp between the `eth_call` and the `rollup_getInfo`

--- a/integration-tests/test/pool_dao_actions.spec.ts
+++ b/integration-tests/test/pool_dao_actions.spec.ts
@@ -299,7 +299,7 @@ describe('Dao Action Test', async () => {
       expect(prexBobaAmount).to.deep.equal(postBobaAmount.sub(depositAmount))
     })
 
-    it('{tag:other} should delegate voting rights', async () => {
+    it('{tag:boba} should delegate voting rights', async () => {
       const delegateTx = await xBoba.delegate(env.l2Wallet.address)
       await delegateTx.wait()
       const updatedDelegate = await xBoba.delegates(env.l2Wallet.address)
@@ -320,7 +320,7 @@ describe('Dao Action Test', async () => {
       initialL2LPOwnerRewardFeeRate = await L2LiquidityPool.ownerRewardFeeRate()
     })
 
-    it('{tag:other} should delegate voting rights', async () => {
+    it('{tag:boba} should delegate voting rights', async () => {
       const delegateTx = await L2Boba.delegate(env.l2Wallet.address)
       await delegateTx.wait()
       const updatedDelegate = await L2Boba.delegates(env.l2Wallet.address)
@@ -330,7 +330,7 @@ describe('Dao Action Test', async () => {
       expect(currentVotes).to.eq(L2BobaBalance)
     })
 
-    it('{tag:other} should create a new proposal to configure fee', async () => {
+    it('{tag:boba} should create a new proposal to configure fee', async () => {
       try {
         const priorProposalID = (await Governor.proposalCount())._hex
         console.log(priorProposalID.toString())
@@ -395,7 +395,7 @@ describe('Dao Action Test', async () => {
       }
     })
 
-    it('{tag:other} should cast vote to the proposal and wait for voting period to end', async () => {
+    it('{tag:boba} should cast vote to the proposal and wait for voting period to end', async () => {
       try {
         // get current voting delay from contract
         const votingDelay = (await Governor.votingDelay()).toNumber()
@@ -432,7 +432,7 @@ describe('Dao Action Test', async () => {
       }
     })
 
-    it('{tag:other} should queue the proposal successfully', async () => {
+    it('{tag:boba} should queue the proposal successfully', async () => {
       const proposalID = (await Governor.proposalCount())._hex
       const queueTx = await Governor.queue(proposalID)
       await queueTx.wait()
@@ -441,7 +441,7 @@ describe('Dao Action Test', async () => {
       expect(proposalStates[state]).to.deep.eq('Queued')
     })
 
-    it('{tag:other} should execute the proposal successfully', async () => {
+    it('{tag:boba} should execute the proposal successfully', async () => {
       const proposalID = (await Governor.proposalCount())._hex
       const executeTx = await Governor.execute(proposalID)
       await executeTx.wait()
@@ -475,7 +475,7 @@ describe('Dao Action Test', async () => {
       initialL1LPOwnerRewardFeeRate = await L1LiquidityPool.ownerRewardFeeRate()
     })
 
-    it('{tag:other} should create a new proposal to configure fee', async () => {
+    it('{tag:boba} should create a new proposal to configure fee', async () => {
       try {
         const priorProposalID = (await Governor.proposalCount())._hex
         if (priorProposalID !== '0x00') {
@@ -537,7 +537,7 @@ describe('Dao Action Test', async () => {
       }
     })
 
-    it('{tag:other} should cast vote to the proposal and wait for voting period to end', async () => {
+    it('{tag:boba} should cast vote to the proposal and wait for voting period to end', async () => {
       try {
         // get current voting delay from contract
         const votingDelay = (await Governor.votingDelay()).toNumber()
@@ -573,7 +573,7 @@ describe('Dao Action Test', async () => {
       }
     })
 
-    it('{tag:other} should queue the proposal successfully', async () => {
+    it('{tag:boba} should queue the proposal successfully', async () => {
       const proposalID = (await Governor.proposalCount())._hex
       const queueTx = await Governor.queue(proposalID)
       await queueTx.wait()
@@ -582,7 +582,7 @@ describe('Dao Action Test', async () => {
       expect(proposalStates[state]).to.deep.eq('Queued')
     })
 
-    it('{tag:other} should execute the proposal successfully', async () => {
+    it('{tag:boba} should execute the proposal successfully', async () => {
       const proposalID = (await Governor.proposalCount())._hex
       const executeTx = await Governor.execute(proposalID)
       await executeTx.wait()

--- a/integration-tests/test/queue-ingestion.spec.ts
+++ b/integration-tests/test/queue-ingestion.spec.ts
@@ -19,7 +19,7 @@ describe('Queue Ingestion', () => {
   // The batch submitter will notice that there are transactions
   // that are in the queue and submit them. L2 will pick up the
   // sequencer batch appended event and play the transactions.
-  it('{tag:other} should order transactions correctly', async () => {
+  it('{tag:boba} should order transactions correctly', async () => {
     const numTxs = 5
 
     // Enqueue some transactions by building the calldata and then sending

--- a/integration-tests/test/replica.spec.ts
+++ b/integration-tests/test/replica.spec.ts
@@ -52,7 +52,7 @@ describe('Syncing a replica', () => {
       Factory__ERC20 = await ethers.getContractFactory('ERC20', wallet)
     })
 
-    it('{tag:other} should sync dummy transaction', async () => {
+    it('{tag:boba} should sync dummy transaction', async () => {
       const tx = {
         to: '0x' + '1234'.repeat(10),
         gasLimit: 4000000,
@@ -76,7 +76,7 @@ describe('Syncing a replica', () => {
       )
     })
 
-    it('{tag:other} should sync ERC20 deployment and transfer', async () => {
+    it('{tag:boba} should sync ERC20 deployment and transfer', async () => {
       ERC20 = await Factory__ERC20.deploy(
         initialAmount,
         tokenName,

--- a/integration-tests/test/routed_exit_burn.spec.ts
+++ b/integration-tests/test/routed_exit_burn.spec.ts
@@ -119,7 +119,7 @@ describe('Standard Exit burn', async () => {
       )
     })
 
-    it('{tag:other} should not allow updating extraGasRelay for non-owner', async () => {
+    it('{tag:boba} should not allow updating extraGasRelay for non-owner', async () => {
       const newExtraGasRelay = 500000
       await expect(
         ExitBurn.connect(env.l2Wallet_2).configureExtraGasRelay(
@@ -128,7 +128,7 @@ describe('Standard Exit burn', async () => {
       ).to.be.revertedWith('caller is not the gasPriceOracle owner')
     })
 
-    it('{tag:other} should allow updating extraGasRelay for owner', async () => {
+    it('{tag:boba} should allow updating extraGasRelay for owner', async () => {
       // approximate and set new extra gas to over it for tests
       const approveBobL2TX = await L2ERC20.approve(
         ExitBurn.address,
@@ -176,7 +176,7 @@ describe('Standard Exit burn', async () => {
       )
     })
 
-    it('{tag:other} should burn and withdraw erc20', async () => {
+    it('{tag:boba} should burn and withdraw erc20', async () => {
       const preBalanceExitorL1 = await L1ERC20.balanceOf(env.l1Wallet.address)
       const preBalanceExitorL2 = await L2ERC20.balanceOf(env.l2Wallet.address)
 
@@ -208,7 +208,7 @@ describe('Standard Exit burn', async () => {
       expect(ExitBurnContractBalance).to.eq(0)
     })
 
-    it('{tag:other} should fail if not enough erc20 balance', async () => {
+    it('{tag:boba} should fail if not enough erc20 balance', async () => {
       const preBalanceExitorL2 = await L2ERC20.balanceOf(env.l2Wallet.address)
 
       expect(preBalanceExitorL2).to.eq(0)
@@ -238,7 +238,7 @@ describe('Standard Exit burn', async () => {
       await env.waitForXDomainTransaction(deposit, Direction.L1ToL2)
     })
 
-    it('{tag:other} should burn and withdraw ovm_eth', async () => {
+    it('{tag:boba} should burn and withdraw ovm_eth', async () => {
       const preBalanceExitorL1 = await env.l1Wallet.getBalance()
       const preBalanceExitorL2 = await env.l2Wallet.getBalance()
 

--- a/integration-tests/test/rpc.spec.ts
+++ b/integration-tests/test/rpc.spec.ts
@@ -64,7 +64,7 @@ describe('Basic RPC tests', () => {
   })
 
   describe('eth_sendRawTransaction', () => {
-    it('{tag:rpc} should correctly process a valid transaction', async () => {
+    it('{tag:boba} should correctly process a valid transaction', async () => {
       const tx = defaultTransactionFactory()
       tx.gasPrice = await gasPriceForL2()
       const nonce = await wallet.getTransactionCount()
@@ -77,7 +77,7 @@ describe('Basic RPC tests', () => {
       expect(result.data).to.equal(tx.data)
     })
 
-    it('{tag:rpc} should not accept a transaction with the wrong chain ID', async () => {
+    it('{tag:boba} should not accept a transaction with the wrong chain ID', async () => {
       const tx = {
         ...defaultTransactionFactory(),
         gasPrice: await gasPriceForL2(),
@@ -89,7 +89,7 @@ describe('Basic RPC tests', () => {
       ).to.be.rejectedWith('invalid transaction: invalid sender')
     })
 
-    it('{tag:rpc} should accept a transaction without a chain ID', async () => {
+    it('{tag:boba} should accept a transaction without a chain ID', async () => {
       const tx = {
         ...defaultTransactionFactory(),
         nonce: await wallet.getTransactionCount(),
@@ -104,7 +104,7 @@ describe('Basic RPC tests', () => {
       expect(v === 27 || v === 28).to.be.true
     })
 
-    it('{tag:rpc} should accept a transaction with a value', async () => {
+    it('{tag:boba} should accept a transaction with a value', async () => {
       const tx = {
         ...defaultTransactionFactory(),
         gasPrice: await gasPriceForL2(),
@@ -123,7 +123,7 @@ describe('Basic RPC tests', () => {
         .be.true
     })
 
-    it('{tag:rpc} should reject a transaction with higher value than user balance', async () => {
+    it('{tag:boba} should reject a transaction with higher value than user balance', async () => {
       const balance = await env.l2Wallet.getBalance()
       const tx = {
         ...defaultTransactionFactory(),
@@ -138,7 +138,7 @@ describe('Basic RPC tests', () => {
       )
     })
 
-    it('{tag:rpc} should correctly report OOG for contract creations', async () => {
+    it('{tag:boba} should correctly report OOG for contract creations', async () => {
       const factory = await ethers.getContractFactory('TestOOGInConstructor')
 
       await expect(factory.connect(wallet).deploy()).to.be.rejectedWith(
@@ -148,7 +148,7 @@ describe('Basic RPC tests', () => {
   })
 
   describe('eth_call', () => {
-    it('{tag:rpc} should correctly identify call out-of-gas', async () => {
+    it('{tag:boba} should correctly identify call out-of-gas', async () => {
       await expect(
         provider.call({
           ...revertingTx,
@@ -157,21 +157,21 @@ describe('Basic RPC tests', () => {
       ).to.be.rejectedWith('out of gas')
     })
 
-    it('{tag:rpc} should correctly return solidity revert data from a call', async () => {
+    it('{tag:boba} should correctly return solidity revert data from a call', async () => {
       await expect(provider.call(revertingTx)).to.be.revertedWith(revertMessage)
     })
 
-    it('{tag:rpc} should produce error when called from ethers', async () => {
+    it('{tag:boba} should produce error when called from ethers', async () => {
       await expect(Reverter.doRevert()).to.be.revertedWith(revertMessage)
     })
 
-    it('{tag:rpc} should correctly return revert data from contract creation', async () => {
+    it('{tag:boba} should correctly return revert data from contract creation', async () => {
       await expect(provider.call(revertingDeployTx)).to.be.revertedWith(
         revertMessage
       )
     })
 
-    it('{tag:rpc} should correctly identify contract creation out of gas', async () => {
+    it('{tag:boba} should correctly identify contract creation out of gas', async () => {
       await expect(
         provider.call({
           ...revertingDeployTx,
@@ -180,7 +180,7 @@ describe('Basic RPC tests', () => {
       ).to.be.rejectedWith('out of gas')
     })
 
-    it('{tag:rpc} should allow eth_calls with nonzero value', async () => {
+    it('{tag:boba} should allow eth_calls with nonzero value', async () => {
       // Deploy a contract to check msg.value of the call
       const Factory__ValueContext: ContractFactory =
         await ethers.getContractFactory('ValueContext', wallet)
@@ -206,7 +206,7 @@ describe('Basic RPC tests', () => {
   })
 
   describe('eth_getTransactionReceipt', () => {
-    it('{tag:rpc} correctly exposes revert data for contract calls', async () => {
+    it('{tag:boba} correctly exposes revert data for contract calls', async () => {
       const req: TransactionRequest = {
         ...revertingTx,
         gasLimit: 8_000_000, // override gas estimation
@@ -229,7 +229,7 @@ describe('Basic RPC tests', () => {
       expect(receipt.status).to.eq(0)
     })
 
-    it('{tag:rpc} correctly exposes revert data for contract creations', async () => {
+    it('{tag:boba} correctly exposes revert data for contract creations', async () => {
       const req: TransactionRequest = {
         ...revertingDeployTx,
         gasLimit: 8_000_000, // override gas estimation
@@ -253,7 +253,7 @@ describe('Basic RPC tests', () => {
     })
 
     // Optimistic Ethereum special fields on the receipt
-    it('{tag:rpc} includes L1 gas price and L1 gas used', async () => {
+    it('{tag:boba} includes L1 gas price and L1 gas used', async () => {
       const tx = await env.l2Wallet.populateTransaction({
         to: env.l2Wallet.address,
         gasPrice: await gasPriceForL2(),
@@ -291,7 +291,7 @@ describe('Basic RPC tests', () => {
   })
 
   describe('eth_getTransactionByHash', () => {
-    it('{tag:rpc} should be able to get all relevant l1/l2 transaction data', async () => {
+    it('{tag:boba} should be able to get all relevant l1/l2 transaction data', async () => {
       const tx = defaultTransactionFactory()
       tx.gasPrice = await gasPriceForL2()
       const result = await wallet.sendTransaction(tx)
@@ -305,7 +305,7 @@ describe('Basic RPC tests', () => {
   })
 
   describe('eth_getBlockByHash', () => {
-    it('{tag:rpc} should return the block and all included transactions', async () => {
+    it('{tag:boba} should return the block and all included transactions', async () => {
       // Send a transaction and wait for it to be mined.
       const tx = defaultTransactionFactory()
       tx.gasPrice = await gasPriceForL2()
@@ -334,7 +334,7 @@ describe('Basic RPC tests', () => {
     // Needs to be skipped on Prod networks because this test doesn't work when
     // other people are sending transactions to the Sequencer at the same time
     // as this test is running.
-    it('{tag:rpc} should return the same result when new transactions are not applied', async function () {
+    it('{tag:boba} should return the same result when new transactions are not applied', async function () {
       if (isLiveNetwork()) {
         this.skip()
       }
@@ -363,7 +363,7 @@ describe('Basic RPC tests', () => {
   })
 
   describe('eth_getBalance', () => {
-    it('{tag:rpc} should get the OVM_ETH balance', async () => {
+    it('{tag:boba} should get the OVM_ETH balance', async () => {
       const rpcBalance = await provider.getBalance(env.l2Wallet.address)
       const contractBalance = await env.ovmEth.balanceOf(env.l2Wallet.address)
       expect(rpcBalance).to.be.deep.eq(contractBalance)
@@ -371,14 +371,14 @@ describe('Basic RPC tests', () => {
   })
 
   describe('eth_chainId', () => {
-    it('{tag:rpc} should get the correct chainid', async () => {
+    it('{tag:boba} should get the correct chainid', async () => {
       const { chainId } = await provider.getNetwork()
       expect(chainId).to.be.eq(L2_CHAINID)
     })
   })
 
   describe('eth_estimateGas', () => {
-    it('{tag:rpc} gas estimation is deterministic', async () => {
+    it('{tag:boba} gas estimation is deterministic', async () => {
       let lastEstimate: BigNumber
       for (let i = 0; i < 10; i++) {
         const estimate = await l2Provider.estimateGas({
@@ -394,7 +394,7 @@ describe('Basic RPC tests', () => {
       }
     })
 
-    it('{tag:rpc} should return a gas estimate for txs with empty data', async () => {
+    it('{tag:boba} should return a gas estimate for txs with empty data', async () => {
       const estimate = await l2Provider.estimateGas({
         to: defaultTransactionFactory().to,
         value: 0,
@@ -403,19 +403,19 @@ describe('Basic RPC tests', () => {
       expectApprox(estimate, 21000, { percentUpperDeviation: 1 })
     })
 
-    it('{tag:rpc} should fail for a reverting call transaction', async () => {
+    it('{tag:boba} should fail for a reverting call transaction', async () => {
       await expect(provider.send('eth_estimateGas', [revertingTx])).to.be
         .reverted
     })
 
-    it('{tag:rpc} should fail for a reverting deploy transaction', async () => {
+    it('{tag:boba} should fail for a reverting deploy transaction', async () => {
       await expect(provider.send('eth_estimateGas', [revertingDeployTx])).to.be
         .reverted
     })
   })
 
   describe('debug_traceTransaction', () => {
-    it('{tag:rpc} should match debug_traceBlock', async () => {
+    it('{tag:boba} should match debug_traceBlock', async () => {
       const storage = new ContractFactory(
         simpleStorageJson.abi,
         simpleStorageJson.bytecode,
@@ -435,7 +435,7 @@ describe('Basic RPC tests', () => {
   })
 
   describe('rollup_gasPrices', () => {
-    it('{tag:rpc} should return the L1 and L2 gas prices', async () => {
+    it('{tag:boba} should return the L1 and L2 gas prices', async () => {
       const result = await provider.send('rollup_gasPrices', [])
       const l1GasPrice = await env.gasPriceOracle.l1BaseFee()
       const l2GasPrice = await env.gasPriceOracle.gasPrice()
@@ -446,7 +446,7 @@ describe('Basic RPC tests', () => {
   })
 
   describe('Replica RPC forward test', () => {
-    it('{tag:rpc} should correctly process a valid transaction', async () => {
+    it('{tag:boba} should correctly process a valid transaction', async () => {
       const tx = defaultTransactionFactory()
       tx.gasPrice = await gasPriceForL2()
       const nonce = await replicaWallet.getTransactionCount()
@@ -460,7 +460,7 @@ describe('Basic RPC tests', () => {
       expect(result.data).to.equal(tx.data)
     })
 
-    it('{tag:rpc} should not accept a transaction with the wrong chain ID', async () => {
+    it('{tag:boba} should not accept a transaction with the wrong chain ID', async () => {
       const tx = {
         ...defaultTransactionFactory(),
         gasPrice: await gasPriceForL2(),
@@ -474,7 +474,7 @@ describe('Basic RPC tests', () => {
       ).to.be.rejectedWith('invalid transaction: invalid sender')
     })
 
-    it('{tag:rpc} should accept a transaction without a chain ID', async () => {
+    it('{tag:boba} should accept a transaction without a chain ID', async () => {
       const tx = {
         ...defaultTransactionFactory(),
         nonce: await replicaWallet.getTransactionCount(),
@@ -490,7 +490,7 @@ describe('Basic RPC tests', () => {
       expect(v === 27 || v === 28).to.be.true
     })
 
-    it('{tag:rpc} should accept a transaction with a value', async () => {
+    it('{tag:boba} should accept a transaction with a value', async () => {
       const tx = {
         ...defaultTransactionFactory(),
         gasPrice: await gasPriceForL2(),
@@ -511,7 +511,7 @@ describe('Basic RPC tests', () => {
         .be.true
     })
 
-    it('{tag:rpc} should reject a transaction with higher value than user balance', async () => {
+    it('{tag:boba} should reject a transaction with higher value than user balance', async () => {
       const balance = await replicaWallet.getBalance()
       const tx = {
         ...defaultTransactionFactory(),
@@ -526,7 +526,7 @@ describe('Basic RPC tests', () => {
       )
     })
 
-    it('{tag:rpc} should correctly report OOG for contract creations', async () => {
+    it('{tag:boba} should correctly report OOG for contract creations', async () => {
       const factory = await ethers.getContractFactory('TestOOGInConstructor')
 
       await expect(factory.connect(replicaWallet).deploy()).to.be.rejectedWith(

--- a/integration-tests/test/selfdestruct.spec.ts
+++ b/integration-tests/test/selfdestruct.spec.ts
@@ -57,7 +57,7 @@ describe('Self Destruct Tests', async () => {
       })
     })
 
-    it('{tag:other} should send funds to the contract', async () => {
+    it('{tag:boba} should send funds to the contract', async () => {
       balanceSelfDestructContractPre = await env.l2Provider.getBalance(
         SelfDestructTest.address
       )
@@ -72,7 +72,7 @@ describe('Self Destruct Tests', async () => {
         await SelfDestructTest.suicideMethod(env.l2Wallet_2.address)
       })
 
-      it('{tag:other} should send all contract funds to receiver', async () => {
+      it('{tag:boba} should send all contract funds to receiver', async () => {
         balanceSelfDestructContractPost = await env.l2Provider.getBalance(
           SelfDestructTest.address
         )
@@ -91,7 +91,7 @@ describe('Self Destruct Tests', async () => {
           await Create2Deployer.deploy()
         })
 
-        it('{tag:other} should not have funds to send', async () => {
+        it('{tag:boba} should not have funds to send', async () => {
           const SelfDestructTestAddressReCreated = await Create2Deployer.t()
           expect(SelfDestructTestAddressReCreated).to.be.eq(
             SelfDestructTestAddress

--- a/integration-tests/test/state-root-verification.spec.ts
+++ b/integration-tests/test/state-root-verification.spec.ts
@@ -25,7 +25,7 @@ describe('Verify State Roots', async () => {
     ).attach(StateCommitmentChainAddress)
   })
 
-  it('{tag:other} State roots should match', async () => {
+  it('{tag:boba} State roots should match', async () => {
     // get latest state root from SCC contract
     const blockInterval = 5000
     const l1BlockNumber = await env.l1Provider.getBlockNumber()

--- a/integration-tests/test/stress-tests.spec.ts
+++ b/integration-tests/test/stress-tests.spec.ts
@@ -74,7 +74,7 @@ describe('stress tests', () => {
   })
 
   describe('L1 => L2 stress tests', () => {
-    it(`{tag:other} ${numTransactions} L1 => L2 transactions (serial)`, async () => {
+    it(`{tag:boba} ${numTransactions} L1 => L2 transactions (serial)`, async () => {
       await executeRepeatedL1ToL2Transactions(env, wallets, {
         contract: L2SimpleStorage,
         functionName: 'setValue',
@@ -86,7 +86,7 @@ describe('stress tests', () => {
       )
     }).timeout(STRESS_TEST_TIMEOUT)
 
-    it(`{tag:other} ${numTransactions} L1 => L2 transactions (parallel)`, async () => {
+    it(`{tag:boba} ${numTransactions} L1 => L2 transactions (parallel)`, async () => {
       await executeL1ToL2TransactionsParallel(env, wallets, {
         contract: L2SimpleStorage,
         functionName: 'setValue',
@@ -100,7 +100,7 @@ describe('stress tests', () => {
   })
 
   describe('L2 => L1 stress tests', () => {
-    it(`{tag:other} ${numTransactions} L2 => L1 transactions (serial)`, async () => {
+    it(`{tag:boba} ${numTransactions} L2 => L1 transactions (serial)`, async () => {
       await executeRepeatedL2ToL1Transactions(env, wallets, {
         contract: L1SimpleStorage,
         functionName: 'setValue',
@@ -112,7 +112,7 @@ describe('stress tests', () => {
       )
     }).timeout(STRESS_TEST_TIMEOUT)
 
-    it(`{tag:other} ${numTransactions} L2 => L1 transactions (parallel)`, async () => {
+    it(`{tag:boba} ${numTransactions} L2 => L1 transactions (parallel)`, async () => {
       await executeL2ToL1TransactionsParallel(env, wallets, {
         contract: L1SimpleStorage,
         functionName: 'setValue',
@@ -126,7 +126,7 @@ describe('stress tests', () => {
   })
 
   describe('L2 transaction stress tests', () => {
-    it(`{tag:other} ${numTransactions} L2 transactions (serial)`, async () => {
+    it(`{tag:boba} ${numTransactions} L2 transactions (serial)`, async () => {
       await executeRepeatedL2Transactions(env, wallets, {
         contract: L2SimpleStorage,
         functionName: 'setValueNotXDomain',
@@ -138,7 +138,7 @@ describe('stress tests', () => {
       )
     }).timeout(STRESS_TEST_TIMEOUT)
 
-    it(`{tag:other} ${numTransactions} L2 transactions (parallel)`, async () => {
+    it(`{tag:boba} ${numTransactions} L2 transactions (parallel)`, async () => {
       await executeL2TransactionsParallel(env, wallets, {
         contract: L2SimpleStorage,
         functionName: 'setValueNotXDomain',
@@ -152,7 +152,7 @@ describe('stress tests', () => {
   })
 
   describe('C-C-C-Combo breakers', () => {
-    it(`{tag:other} ${numTransactions} L2 transactions, L1 => L2 transactions, L2 => L1 transactions (txs serial, suites parallel)`, async () => {
+    it(`{tag:boba} ${numTransactions} L2 transactions, L1 => L2 transactions, L2 => L1 transactions (txs serial, suites parallel)`, async () => {
       await Promise.all([
         executeRepeatedL1ToL2Transactions(env, wallets, {
           contract: L2SimpleStorage,
@@ -180,7 +180,7 @@ describe('stress tests', () => {
       )
     }).timeout(STRESS_TEST_TIMEOUT)
 
-    it(`{tag:other} ${numTransactions} L2 transactions, L1 => L2 transactions, L2 => L1 transactions (all parallel)`, async () => {
+    it(`{tag:boba} ${numTransactions} L2 transactions, L1 => L2 transactions, L2 => L1 transactions (all parallel)`, async () => {
       await Promise.all([
         executeL1ToL2TransactionsParallel(env, wallets, {
           contract: L2SimpleStorage,
@@ -211,7 +211,7 @@ describe('stress tests', () => {
 
   // These tests depend on an archive node due to the historical `eth_call`s
   describe('Monotonicity Checks', () => {
-    it('{tag:other} should have monotonic timestamps and l1 blocknumbers', async () => {
+    it('{tag:boba} should have monotonic timestamps and l1 blocknumbers', async () => {
       const tip = await env.l2Provider.getBlock('latest')
       const prev = {
         block: await env.l2Provider.getBlock(0),

--- a/integration-tests/test/whitelist.spec.ts
+++ b/integration-tests/test/whitelist.spec.ts
@@ -25,7 +25,7 @@ describe('Whitelist', async () => {
   })
 
   describe('when the whitelist is disabled', () => {
-    it('{tag:other} should be able to deploy a contract', async () => {
+    it('{tag:boba} should be able to deploy a contract', async () => {
       await expect(
         l2Provider.send('eth_call', [
           Factory__ERC20.getDeployTransaction(
@@ -51,7 +51,7 @@ describe('Whitelist', async () => {
   describe('when the whitelist is enabled', () => {
     const sender = '0x' + '22'.repeat(20)
 
-    it('{tag:other} should fail if the user is not whitelisted', async () => {
+    it('{tag:boba} should fail if the user is not whitelisted', async () => {
       await expect(
         l2Provider.send('eth_call', [
           {
@@ -78,7 +78,7 @@ describe('Whitelist', async () => {
       ).to.be.revertedWith(`deployer address not whitelisted: ${sender}`)
     })
 
-    it('{tag:other} should succeed if the user is whitelisted', async () => {
+    it('{tag:boba} should succeed if the user is whitelisted', async () => {
       await expect(
         l2Provider.send('eth_call', [
           {

--- a/packages/boba/contracts/deploy/013-BobaDao.deploy.ts
+++ b/packages/boba/contracts/deploy/013-BobaDao.deploy.ts
@@ -209,65 +209,80 @@ const deployFn: DeployFunction = async (hre) => {
     [[]]
   )
 
-  const initiateTx = await Timelock.queueTransaction(
-    GovernorBravoDelegator.address,
-    0,
-    '_initiate()',
-    initiateData,
-    eta2
-  )
+  // currently fails with
+  // "error": "ERROR processing /opt/optimism/packages/boba/contracts/deploy/013-BobaDao.deploy.ts:\n
+  // Error: transaction failed (transactionHash=\"0xc34a9170256522952a71549aea8f1d642e9c39f05b35d3ec6959f00b359a5067\", 
+  // transaction={\"nonce\":63,\"gasPrice\":{\"type\":\"BigNumber\",\"hex\":\"0x3b9aca00\"},\"gasLimit\":
+  // {\"type\":\"BigNumber\",\"hex\":\"0xda50\"},\"to\":\"0xFD471836031dc5108809D173A067e8486B9047A3\",\"value\":{\"type\":\"
+  // BigNumber\",\"hex\":\"0x00\"},\"
+  // data\":\"0x3a66f9010000000000000000000000001429859428c0abc9c2c47c8ee9fbaf82cfa0f20f000000000000000000000000000000000000000000000000000000000000000000000000000000
+  // 000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000e000000000000000000000000000000000000000000000000
+  // 00000000062217180000000000000000000000000000000000000000000000000000000000000000b5f696e69746961746528290000000000000000000000000000000000000000000000000000000000
+  //000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000
+  // 00000000000000\",\"chainId\":31338,\"v\":62711,\"r\":\"0x02d0abd9819598fd9c92fab284a4868860b81ba1fa2703e25049dc74a635d045\",\"s\":\"0x619490b70938c47195a48af2cfd
+  // 79c27265914c4e97cc69e90329e0b3b8d56d5\",\"from\":\"0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266\",\"hash\":\"0xc34a9170256522952a71549aea8f1d642e9c39f05b35d3ec6959
+  // f00b359a5067\",\"type\":null,\"confirmations\":0}, receipt={\"to\":\"0xFD471836031dc5108809D173A067e8486B9047A3\",\"from\":\"0xf39Fd6e51aad88F6F4ce6aB8827279cffF
+  // b92266\",\"contractAddress\":null,\"transactionIndex\":0,\"gasUsed\":
 
-  await initiateTx.wait()
+  // const initiateTx = await Timelock.queueTransaction(
+  //   GovernorBravoDelegator.address,
+  //   0,
+  //   '_initiate()',
+  //   initiateData,
+  //   eta2
+  // )
 
-  console.log('Queued Initiate!')
-  console.log(`Time transaction was made: ${await getTimestamp(hre)}`)
-  console.log(`Time at which transaction can be executed: ${eta2}`)
+  // await initiateTx.wait()
 
-  // if it's local/rinkeby attempt to execute transactions
-  if (process.env.NETWORK !== 'mainnet') {
-    console.log('Execute setPendingAdmin...')
-    // Execute the transaction that will set the admin of Timelock to the GovernorBravoDelegator contract
-    await Timelock.executeTransaction(
-      Timelock.address,
-      0,
-      'setPendingAdmin(address)', // the function to be called
-      setPendingAdminData,
-      eta1
-    )
-    console.log('Executed setPendingAdmin!')
+  // console.log('Queued Initiate!')
+  // console.log(`Time transaction was made: ${await getTimestamp(hre)}`)
+  // console.log(`Time at which transaction can be executed: ${eta2}`)
 
-    console.log('Execute initiate...')
+  // // if it's local/rinkeby attempt to execute transactions
+  // if (process.env.NETWORK !== 'mainnet') {
+  //   console.log('Execute setPendingAdmin...')
+  //   // Execute the transaction that will set the admin of Timelock to the GovernorBravoDelegator contract
+  //   await Timelock.executeTransaction(
+  //     Timelock.address,
+  //     0,
+  //     'setPendingAdmin(address)', // the function to be called
+  //     setPendingAdminData,
+  //     eta1
+  //   )
+  //   console.log('Executed setPendingAdmin!')
 
-    await Timelock.executeTransaction(
-      GovernorBravoDelegator.address,
-      0,
-      '_initiate()',
-      initiateData,
-      eta2
-    )
-    console.log('Executed initiate, acceptAdmin() completed')
-  } else {
-    // TODO - replace with a script that can be called on ETA instead
-    console.log(
-      '\nPlease copy these values and call executeTransaction() on Timelock twice'
-    )
-    console.log(
-      'from the deployer account in the following sequence with the below parameters'
-    )
-    console.log('when the ETA is reached')
-    console.log('---------------------------')
-    console.log('target :', Timelock.address)
-    console.log('value :', 0)
-    console.log('signature : setPendingAdmin(address)')
-    console.log('data :', setPendingAdminData)
-    console.log('eta :', eta1)
-    console.log('---------------------------')
-    console.log('target :', GovernorBravoDelegator.address)
-    console.log('value :', 0)
-    console.log('signature : _initiate()')
-    console.log('data :', initiateData)
-    console.log('eta :', eta2)
-  }
+  //   console.log('Execute initiate...')
+
+  //   await Timelock.executeTransaction(
+  //     GovernorBravoDelegator.address,
+  //     0,
+  //     '_initiate()',
+  //     initiateData,
+  //     eta2
+  //   )
+  //   console.log('Executed initiate, acceptAdmin() completed')
+  // } else {
+  //   // TODO - replace with a script that can be called on ETA instead
+  //   console.log(
+  //     '\nPlease copy these values and call executeTransaction() on Timelock twice'
+  //   )
+  //   console.log(
+  //     'from the deployer account in the following sequence with the below parameters'
+  //   )
+  //   console.log('when the ETA is reached')
+  //   console.log('---------------------------')
+  //   console.log('target :', Timelock.address)
+  //   console.log('value :', 0)
+  //   console.log('signature : setPendingAdmin(address)')
+  //   console.log('data :', setPendingAdminData)
+  //   console.log('eta :', eta1)
+  //   console.log('---------------------------')
+  //   console.log('target :', GovernorBravoDelegator.address)
+  //   console.log('value :', 0)
+  //   console.log('signature : _initiate()')
+  //   console.log('data :', initiateData)
+  //   console.log('eta :', eta2)
+  // }
 }
 
 deployFn.tags = ['DAO', 'BOBA']


### PR DESCRIPTION
The boba_deployer sequence currently breaks at 
```
  // const initiateTx = await Timelock.queueTransaction(
  //   GovernorBravoDelegator.address,
  //   0,
  //   '_initiate()',
  //   initiateData,
  //   eta2
  // )

  // await initiateTx.wait()
```
This is not a critical part of the contract deployment stack? Commented out for now...