### PR TITLE
update standard ERC721 contracts to include metadata

### DIFF
--- a/integration-tests/test/nft_bridge.spec.ts
+++ b/integration-tests/test/nft_bridge.spec.ts
@@ -64,7 +64,8 @@ describe('NFT Bridge Test', async () => {
         L2Bridge.address,
         L1ERC721.address,
         'Test',
-        'TST'
+        'TST',
+        '' // base-uri
       )
 
       await L2ERC721.deployTransaction.wait()
@@ -273,7 +274,8 @@ describe('NFT Bridge Test', async () => {
         L1Bridge.address,
         L2ERC721.address,
         'Test',
-        'TST'
+        'TST',
+        '' // base-uri
       )
 
       await L1ERC721.deployTransaction.wait()
@@ -494,7 +496,8 @@ describe('NFT Bridge Test', async () => {
         L2Bridge.address,
         L1ERC721.address,
         'Test',
-        'TST'
+        'TST',
+        '' // base-uri
       )
 
       await L2ERC721.deployTransaction.wait()
@@ -578,7 +581,8 @@ describe('NFT Bridge Test', async () => {
         L1Bridge.address,
         L2ERC721.address,
         'Test',
-        'TST'
+        'TST',
+        '' // base-uri
       )
 
       await L1ERC721.deployTransaction.wait()
@@ -660,7 +664,8 @@ describe('NFT Bridge Test', async () => {
         L2Bridge.address,
         L1ERC721.address,
         'Test',
-        'TST'
+        'TST',
+        '' // base-uri
       )
 
       await L2ERC721.deployTransaction.wait()
@@ -816,7 +821,8 @@ describe('NFT Bridge Test', async () => {
         L1Bridge.address,
         L2ERC721.address,
         'Test',
-        'TST'
+        'TST',
+        '' // base-uri
       )
 
       await L1ERC721.deployTransaction.wait()

--- a/packages/boba/contracts/contracts/bridges/README.md
+++ b/packages/boba/contracts/contracts/bridges/README.md
@@ -19,7 +19,7 @@ Boba NFT bridges support **native L1 NFTs** and **native L2 NFTs** to be moved b
 * Native L1 NFT: the original NFT contract was deployed on L1
 * Native L2 NFT: the original NFT contract was deployed on L2
 
-Bridging an NFT to Boba takes several minutes, and bridging an NFT from Boba to Ethereum takes 7 days. **Not all NFTs are bridgeable - developers must use specialized NFT contracts (e.g. L2StandardERC721.sol) to enable this functionality.** 
+Bridging an NFT to Boba takes several minutes, and bridging an NFT from Boba to Ethereum takes 7 days. **Not all NFTs are bridgeable - developers must use specialized NFT contracts (e.g. L2StandardERC721.sol) to enable this functionality.**
 
 ## Native L1 NFT - Developer Requirements
 
@@ -34,8 +34,9 @@ const Factory__L2StandardERC721 = new ethers.ContractFactory(
 const L2StandardERC721 = await Factory__L2StandardERC721.deploy(
   L2_NFT_BRIDGE_ADDRESS,   // L2 NFT Bridge Address
   L1_NFT_CONTRACT_ADDRESS, // Your L1 NFT Address
-  NFT_NAME, 
-  NFT_SYMBOL
+  NFT_NAME,
+  NFT_SYMBOL,
+  BASE_URI
 )
 await L2StandardERC721.deployTransaction.wait()
 ```
@@ -55,8 +56,9 @@ const Factory__L1StandardERC721 = new ethers.ContractFactory(
 const L1StandardERC721 = await Factory__L1StandardERC721.deploy(
   L1_NFT_BRIDGE_ADDRESS, // L1 NFT Bridge Address
   L2_NFT_CONTRACT_ADDRESS, // Your L2 NFT Address
-  NFT_NAME, 
-  NFT_SYMBOL
+  NFT_NAME,
+  NFT_SYMBOL,
+  BASE_URI
 )
 await L2StandardERC721.deployTransaction.wait()
 ```

--- a/packages/boba/contracts/contracts/standards/L1StandardERC721.sol
+++ b/packages/boba/contracts/contracts/standards/L1StandardERC721.sol
@@ -1,13 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >0.7.5;
 
-import "@openzeppelin/contracts/token/ERC721/extensions/ERC721URIStorage.sol";
+import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 
 import "./IL1StandardERC721.sol";
 
-contract L1StandardERC721 is IL1StandardERC721, ERC721URIStorage {
+contract L1StandardERC721 is IL1StandardERC721, ERC721 {
     address public override l2Contract;
     address public l1Bridge;
+    string private baseTokenURI;
 
     /**
      * @param _l1Bridge Address of the L1 standard bridge.
@@ -19,11 +20,13 @@ contract L1StandardERC721 is IL1StandardERC721, ERC721URIStorage {
         address _l1Bridge,
         address _l2Contract,
         string memory _name,
-        string memory _symbol
+        string memory _symbol,
+        string memory _baseTokenURI
     )
         ERC721(_name, _symbol) {
         l2Contract = _l2Contract;
         l1Bridge = _l1Bridge;
+        baseTokenURI = _baseTokenURI;
     }
 
     modifier onlyL1Bridge {
@@ -50,5 +53,9 @@ contract L1StandardERC721 is IL1StandardERC721, ERC721URIStorage {
         _burn(_tokenId);
 
         emit Burn(_tokenId);
+    }
+
+    function _baseURI() internal view virtual override returns (string memory) {
+        return baseTokenURI;
     }
 }

--- a/packages/boba/contracts/contracts/standards/L2StandardERC721.sol
+++ b/packages/boba/contracts/contracts/standards/L2StandardERC721.sol
@@ -1,13 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >0.7.5;
 
-import "@openzeppelin/contracts/token/ERC721/extensions/ERC721URIStorage.sol";
+import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 
 import "./IL2StandardERC721.sol";
 
-contract L2StandardERC721 is IL2StandardERC721, ERC721URIStorage {
+contract L2StandardERC721 is IL2StandardERC721, ERC721 {
     address public override l1Contract;
     address public l2Bridge;
+    string private baseTokenURI;
 
     /**
      * @param _l2Bridge Address of the L2 standard bridge.
@@ -19,11 +20,13 @@ contract L2StandardERC721 is IL2StandardERC721, ERC721URIStorage {
         address _l2Bridge,
         address _l1Contract,
         string memory _name,
-        string memory _symbol
+        string memory _symbol,
+        string memory _baseTokenURI
     )
         ERC721(_name, _symbol) {
         l1Contract = _l1Contract;
         l2Bridge = _l2Bridge;
+        baseTokenURI = _baseTokenURI;
     }
 
     modifier onlyL2Bridge {
@@ -50,5 +53,9 @@ contract L2StandardERC721 is IL2StandardERC721, ERC721URIStorage {
         _burn(_tokenId);
 
         emit Burn(_tokenId);
+    }
+
+    function _baseURI() internal view virtual override returns (string memory) {
+        return baseTokenURI;
     }
 }

--- a/packages/boba/contracts/deploy/011-L2ERC721.deploy.ts
+++ b/packages/boba/contracts/deploy/011-L2ERC721.deploy.ts
@@ -46,7 +46,8 @@ const deployFn: DeployFunction = async (hre) => {
         L2NFTBridge.address,
         tokenAddress,
         token.name,
-        token.symbol
+        token.symbol,
+        token.baseURI //base-uri
       )
       await L2ERC721.deployTransaction.wait()
 

--- a/packages/boba/contracts/preSupportedNFTs.json
+++ b/packages/boba/contracts/preSupportedNFTs.json
@@ -3,6 +3,7 @@
       {
          "name": "Bored_Ape_Yacht_Club",
          "symbol": "BAYC",
+         "baseURI": "ipfs://QmeSjSinHpPnmXmspMjwiXyN6zS4E9zccariGR3jxcaWtq/",
          "address": {
              "mainnet":"0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D"
           }
@@ -10,6 +11,7 @@
       {
          "name": "Ethereum_Naming_Service",
          "symbol": "ENS",
+         "baseURI": "",
          "address": {
              "mainnet":"0x57f1887a8bf19b14fc0df6fd9b2acc9af147ea85"
           }
@@ -17,6 +19,7 @@
       {
          "name": "Cool_Cats",
          "symbol": "COOL",
+         "baseURI": "https://api.coolcatsnft.com/cat/",
          "address": {
              "mainnet":"0x1a92f7381b9f03921564a437210bb9396471050c"
           }
@@ -24,6 +27,7 @@
       {
          "name": "Pudgy_Penguins",
          "symbol": "PPG",
+         "baseURI": "https://ipfs.io/ipfs/QmWXJXRdExse2YHRY21Wvh4pjRxNRQcWVhcKw4DLVnqGqs/",
          "address": {
              "mainnet":"0xBd3531dA5CF5857e7CfAA92426877b022e612cf8"
           }
@@ -31,6 +35,7 @@
       {
          "name": "Yat_NFT",
          "symbol": "Yats",
+         "baseURI": "https://a.y.at/nft_transfers/metadata/",
          "address": {
              "mainnet":"0x7d256d82b32d8003d1ca1a1526ed211e6e0da9e2"
           }
@@ -38,6 +43,7 @@
       {
          "name": "CryptoKitties",
          "symbol": "CK",
+         "baseURI": "",
          "address": {
              "mainnet":"0x06012c8cf97BEaD5deAe237070F9587f8E7A266d"
           }


### PR DESCRIPTION
- update L1/L2StandardERC721 to include baseURI
by allowing baseURI to be specified when deployed the standard contract. This doesn't have clear support to update the string after deployment. Another option could have been to make the contracts ownable - which increases flexibility however also increases trust

This standard should cater to all general nfts with off-chain metadata. can be treated as a transitory step - support for on-chain nfts will be added by further updating the standard or introducing a new one